### PR TITLE
Fix Plex history item access

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The application expects the following API credentials:
 - `TRAKT_ACCESS_TOKEN` – access token for Trakt.
 - `TRAKT_CLIENT_ID` – client ID for your Trakt application.
 
+The application uses `plexapi` version 4.15 or newer (but below 5).
+
 If you don't already have the tokens, please see the next sections on how to obtain them.
 
 ## Getting a Plex token

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask
 requests
 APScheduler
-plexapi
+plexapi>=4.15,<5
 


### PR DESCRIPTION
## Summary
- support PlexAPI >=4.13 by reloading history entries with `source()`
- pin `plexapi` dependency range
- document required PlexAPI version

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842fb6b29f4832e9beab6073b69c046