### PR TITLE
Add interactive Trakt OAuth token retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+output.log
+trakt_tokens.json

--- a/README.md
+++ b/README.md
@@ -50,7 +50,14 @@ If you don't already have the tokens, please see the next sections on how to obt
      }'
    ```
 
-   The response contains an `access_token` and `refresh_token`. Save both along with the client ID and client secret.
+   The response contains an `access_token` and `refresh_token`. Save both along
+   with the client ID and client secret.
+
+Once the application is running it will look for these tokens in the
+environment. If they are missing, PlexyTrackt shows a web page asking for the
+authorization code. Enter the code from the Trakt authorization page and the
+application will automatically exchange it for an access and refresh token and
+store them in `trakt_tokens.json` for future use.
 
 ## Running with Docker Compose
 

--- a/templates/authorize.html
+++ b/templates/authorize.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Authorize Trakt</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<div class="container">
+    <h1>Trakt Authorization</h1>
+    <p>Visit <a href="{{ auth_url }}" target="_blank">{{ auth_url }}</a> and authorize the application.</p>
+    <p>Then enter the code provided by Trakt:</p>
+    <form method="post">
+        <input type="text" name="code" placeholder="Authorization code">
+        <button type="submit">Submit</button>
+    </form>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow storing Trakt tokens in `trakt_tokens.json`
- add helper functions to load, save and acquire tokens via OAuth
- refresh tokens are saved when renewed
- show new authorization screen when tokens are missing
- start scheduler only after successful connections

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68430f8fe58c832ea193da894932935d