### PR TITLE
Fix Plex history parsing for datetime values

### DIFF
--- a/app.py
+++ b/app.py
@@ -133,7 +133,10 @@ def get_plex_history(plex):
         watched_ts = getattr(entry, "viewedAt", None)
         watched_at = None
         if watched_ts:
-            watched_at = datetime.utcfromtimestamp(int(watched_ts)).isoformat() + "Z"
+            if isinstance(watched_ts, datetime):
+                watched_at = watched_ts.isoformat() + "Z"
+            else:
+                watched_at = datetime.utcfromtimestamp(int(watched_ts)).isoformat() + "Z"
         if entry.type == 'movie':
             title = getattr(entry, 'title', None)
             year = getattr(entry, 'year', None)


### PR DESCRIPTION
## Summary
- handle `entry.viewedAt` that may already be a `datetime`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6843159d6af0832e95419905f6f75465