### PR TITLE
Translate comments and modernize UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ The application expects the following API credentials:
 - `TRAKT_CLIENT_ID` – client ID for your Trakt application.
 - `TRAKT_CLIENT_SECRET` – client secret from your Trakt application.
 
+You do **not** need to provide a Trakt access token or refresh token. The web
+interface will guide you through authorizing the app and will store the tokens
+for you.
+
 The application uses `plexapi` version 4.15 or newer (but below 5).
 
 If you don't already have the Trakt credentials, please see the next sections on how to obtain them.
@@ -27,29 +31,7 @@ If you don't already have the Trakt credentials, please see the next sections on
 1. Log in to your Trakt account and open <https://trakt.tv/oauth/applications>.
 2. Create a new application. Any name will work and you can use `urn:ietf:wg:oauth:2.0:oob` as the redirect URL.
 3. After saving the app you will see a **Client ID** and **Client Secret**. Keep them handy.
-4. Visit the following URL in your browser, replacing `YOUR_CLIENT_ID` with the value from step 3:
-
-   ```
-   https://trakt.tv/oauth/authorize?response_type=code&client_id=YOUR_CLIENT_ID&redirect_uri=urn:ietf:wg:oauth:2.0:oob
-   ```
-
-   Authorize the application and copy the code shown on the page.
-5. Exchange the code for an access token:
-
-   ```bash
-   curl -X POST https://api.trakt.tv/oauth/token \
-     -H "Content-Type: application/json" \
-     -d '{
-       "code": "YOUR_CODE",
-       "client_id": "YOUR_CLIENT_ID",
-       "client_secret": "YOUR_CLIENT_SECRET",
-       "redirect_uri": "urn:ietf:wg:oauth:2.0:oob",
-       "grant_type": "authorization_code"
-     }'
-   ```
-
-   The response contains an `access_token` and `refresh_token`. Save both along
-   with the client ID and client secret.
+4. Start PlexyTrackt and open `http://localhost:5000` in your browser. The page will provide a link to authorize the application on Trakt. After authorizing, paste the code shown by Trakt into the form. The app will handle exchanging the code for tokens automatically.
 
 
 ## Running with Docker Compose

--- a/static/style.css
+++ b/static/style.css
@@ -1,25 +1,47 @@
 body {
-    font-family: Arial, sans-serif;
-    background-color: #f5f5f5;
+    font-family: 'Roboto', Arial, sans-serif;
+    background: linear-gradient(135deg, #ff4081, #7c4dff);
+    color: #ffffff;
     margin: 0;
     padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
 }
+
 .container {
-    max-width: 600px;
-    margin: 50px auto;
-    background: #fff;
-    padding: 20px;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    width: 90%;
+    max-width: 500px;
+    background: rgba(255, 255, 255, 0.1);
+    padding: 30px;
+    border-radius: 12px;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.2);
+    backdrop-filter: blur(10px);
 }
+
 label, input, button {
     font-size: 1em;
 }
+
 input {
-    margin-left: 10px;
-    padding: 5px;
+    margin-top: 10px;
+    width: 100%;
+    padding: 8px;
+    border: none;
+    border-radius: 4px;
 }
+
 button {
-    margin-left: 10px;
-    padding: 5px 10px;
+    margin-top: 15px;
+    padding: 10px 15px;
+    border: none;
+    border-radius: 4px;
+    background-color: #ff4081;
+    color: #fff;
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: #f50057;
 }

--- a/templates/authorize.html
+++ b/templates/authorize.html
@@ -2,7 +2,10 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Authorize Trakt</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Plex Trakt Sync</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- translate Spanish comments in `app.py` into English
- clarify in the README that Trakt access tokens are obtained via the web UI
- modernize styles for the web interface
- add responsive headers in HTML templates

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684323a1d544832eb34f34cdc5ffc3a1