### PR TITLE
Fix auth link overflow

### DIFF
--- a/templates/authorize.html
+++ b/templates/authorize.html
@@ -11,7 +11,7 @@
 <body>
 <div class="container">
     <h1>Trakt Authorization</h1>
-    <p>Visit <a href="{{ auth_url }}" target="_blank">{{ auth_url }}</a> and authorize the application.</p>
+    <p>Visit <a href="{{ auth_url }}" target="_blank">this link</a> and authorize the application.</p>
     <p>Then enter the code provided by Trakt:</p>
     <form method="post">
         <input type="text" name="code" placeholder="Authorization code">


### PR DESCRIPTION
## Summary
- keep the authorization link inside the layout by shortening the text

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684327080094832e84e74b9aca1e617d