### PR TITLE
Implement stop button and avoid duplicate scrobbles

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ TRAKT_CLIENT_SECRET=YOUR_TRAKT_CLIENT_SECRET
 docker-compose up --build
 ```
 
-4. Visit `http://localhost:5000` in your browser. You can adjust the sync interval on the page. The background job starts automatically when the container is running.
+4. Visit `http://localhost:5000` in your browser. You can adjust the sync interval on the page and also stop the synchronization job at any time using the **Stop Sync** button. The background job starts automatically when the container is running.
 
 That's it! The container will continue to sync your Plex and Trakt accounts according to the interval you set.
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,6 +16,9 @@
         <input type="number" id="minutes" name="minutes" min="1" value="{{ minutes }}">
         <button type="submit">Update</button>
     </form>
+    <form method="post" action="{{ url_for('stop') }}">
+        <button type="submit">Stop Sync</button>
+    </form>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add *Stop Sync* button to UI to pause synchronization
- expose `/stop` route and supporting scheduler helper
- skip movies if their GUID already exists in Trakt history
- mention stop feature in README

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6844225aa3ec832e9e5f251b574750c2