### PR TITLE
Add advanced Trakt sync options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # PlexyTrackt
 
-This project syncs watched history between Plex and Trakt. It runs a small Flask web interface that allows you to configure the sync interval. The actual synchronization happens in the background using the APIs of both services.
-Items that are manually marked as watched in Plex are detected as well.
+This project synchronizes your Plex library with Trakt. Besides watched history it can optionally add items to your Trakt collection, sync ratings, keep watchlists up to date and import movies from lists you like on Trakt. A small Flask web interface lets you choose which features to enable and configure the sync interval. Items that are manually marked as watched in Plex are detected as well.
 
 ## Requirements
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,6 +14,13 @@
     <form method="post">
         <label for="minutes">Sync every (minutes):</label>
         <input type="number" id="minutes" name="minutes" min="1" value="{{ minutes }}">
+        <div class="options">
+            <label><input type="checkbox" name="collection" {% if collection %}checked{% endif %}> Sync collection</label><br>
+            <label><input type="checkbox" name="ratings" {% if ratings %}checked{% endif %}> Sync ratings</label><br>
+            <label><input type="checkbox" name="watched" {% if watched %}checked{% endif %}> Sync watched history</label><br>
+            <label><input type="checkbox" name="liked_lists" {% if liked_lists %}checked{% endif %}> Sync liked lists</label><br>
+            <label><input type="checkbox" name="watchlists" {% if watchlists %}checked{% endif %}> Sync watchlists</label>
+        </div>
         <button type="submit">Update</button>
     </form>
     <form method="post" action="{{ url_for('stop') }}">


### PR DESCRIPTION
## Summary
- support optional collection, rating, and watchlist syncing
- update Flask UI with checkboxes to choose which features run
- document new capabilities

## Testing
- `python3 -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684427884fb0832ea8e0c40973bca6d6