### PR TITLE
Align checkboxes with text lines

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -45,3 +45,9 @@ button {
 button:hover {
     background-color: #f50057;
 }
+
+.options label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}


### PR DESCRIPTION
## Summary
- add styling rule for `.options label` to align checkboxes and text

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68444fe68edc832e8e11d09a9e15f4a7