### PR TITLE
Add TZ variable for correct log timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The application expects the following API credentials:
 - `PLEX_TOKEN` – your Plex authentication token.
 - `TRAKT_CLIENT_ID` – client ID for your Trakt application.
 - `TRAKT_CLIENT_SECRET` – client secret from your Trakt application.
+- `TZ` – timezone for log timestamps, defaults to `Europe/Madrid`.
 
 You do **not** need to provide a Trakt access token or refresh token. The web
 interface will guide you through authorizing the app and will store the tokens
@@ -44,6 +45,7 @@ PLEX_BASEURL=http://localhost:32400
 PLEX_TOKEN=YOUR_PLEX_TOKEN
 TRAKT_CLIENT_ID=YOUR_TRAKT_CLIENT_ID
 TRAKT_CLIENT_SECRET=YOUR_TRAKT_CLIENT_SECRET
+TZ=Europe/Madrid
 ```
 
 3. Build and start the application using Docker Compose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     env_file:
       - .env
     environment:
+      - TZ=${TZ:-Europe/Madrid}
       - PLEX_BASEURL=${PLEX_BASEURL}
       - PLEX_TOKEN=${PLEX_TOKEN}
       - TRAKT_CLIENT_ID=${TRAKT_CLIENT_ID}


### PR DESCRIPTION
## Summary
- default timezone to `Europe/Madrid`
- update Docker Compose to pass `TZ` environment variable
- document the new variable in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684455de6fc8832e9836e4c0862acea7