### PR TITLE
Fix sync messages and checkbox alignment

### DIFF
--- a/app.py
+++ b/app.py
@@ -895,8 +895,11 @@ def index():
         SYNC_WATCHLISTS = request.form.get("watchlists") is not None
         scheduler.remove_all_jobs()
         scheduler.add_job(sync, "interval", minutes=minutes, id="sync_job")
-        return redirect(url_for("index"))
+        return redirect(
+            url_for("index", message="Sync settings updated successfully!")
+        )
 
+    message = request.args.get("message")
     return render_template(
         "index.html",
         minutes=SYNC_INTERVAL_MINUTES,
@@ -905,13 +908,14 @@ def index():
         watched=SYNC_WATCHED,
         liked_lists=SYNC_LIKED_LISTS,
         watchlists=SYNC_WATCHLISTS,
+        message=message,
     )
 
 
 @app.route("/stop", methods=["POST"])
 def stop():
     stop_scheduler()
-    return redirect(url_for("index"))
+    return redirect(url_for("index", message="Sync stopped successfully!"))
 
 
 # --------------------------------------------------------------------------- #

--- a/static/style.css
+++ b/static/style.css
@@ -68,7 +68,7 @@ button:hover {
 
 .option-label {
     display: flex;
-    justify-content: space-between;
+    gap: 8px;
     align-items: center;
     width: 100%;
     font-size: 1em;
@@ -81,16 +81,14 @@ button:hover {
 
 .options label {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
     width: 100%;
     padding: 6px 0;
-    gap: 12px;
+    gap: 8px;
 }
 
 .options input[type="checkbox"] {
     margin: 0;
-    margin-right: 12px;
+    margin-right: 0;
     accent-color: #43a047;
     width: 18px;
     height: 18px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,37 +41,19 @@
         
         <div style="display: flex; gap: 10px; justify-content: center;">
             <button type="submit" id="syncBtn">Sync</button>
-            <form method="post" action="{{ url_for('stop') }}" style="margin: 0;">
-                <button type="submit" id="stopBtn">Stop Sync</button>
-            </form>
         </div>
-        
-        <div id="confirmationMessage" class="confirmation-message" style="display: none;"></div>
     </form>
-    
+
+    <form method="post" action="{{ url_for('stop') }}" style="margin: 10px 0 0 0; display:flex; justify-content:center;">
+        <button type="submit" id="stopBtn">Stop Sync</button>
+    </form>
+
+    <div id="confirmationMessage" class="confirmation-message{% if message %} success{% endif %}" {% if not message %}style="display:none;"{% endif %}>{{ message }}</div>
+
     <script>
-        document.getElementById('syncBtn').addEventListener('click', function() {
-            setTimeout(function() {
-                showConfirmationMessage('Sync settings updated successfully!', 'success');
-            }, 100);
-        });
-        
-        document.getElementById('stopBtn').addEventListener('click', function() {
-            setTimeout(function() {
-                showConfirmationMessage('Sync stopped successfully!', 'success');
-            }, 100);
-        });
-        
-        function showConfirmationMessage(message, type) {
-            const messageDiv = document.getElementById('confirmationMessage');
-            messageDiv.textContent = message;
-            messageDiv.className = 'confirmation-message ' + type;
-            messageDiv.style.display = 'block';
-            
-            // Hide message after 3 seconds
-            setTimeout(function() {
-                messageDiv.style.display = 'none';
-            }, 3000);
+        const msg = document.getElementById('confirmationMessage');
+        if (msg.textContent.trim() !== '') {
+            setTimeout(function() { msg.style.display = 'none'; }, 3000);
         }
     </script>
 </div>


### PR DESCRIPTION
## Summary
- show server-side confirmation messages
- align checkboxes vertically
- simplify layout to avoid nested forms

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684461ea23c4832e859656ac6bac3422