### PR TITLE
Improve UI spacing and defaults

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 app = Flask(__name__)
 
 SYNC_INTERVAL_MINUTES = 60           # default frequency
-SYNC_COLLECTION = True
+SYNC_COLLECTION = False
 SYNC_RATINGS = True
 SYNC_WATCHED = True              # ahora sí se respeta este flag
 SYNC_LIKED_LISTS = False

--- a/static/style.css
+++ b/static/style.css
@@ -11,13 +11,15 @@ body {
 }
 
 .container {
-    width: 90%;
+    width: calc(100% - 60px);
     max-width: 500px;
     background: #fff;
     padding: 30px;
     border-radius: 12px;
     box-shadow: 0 4px 16px rgba(0,0,0,0.2);
     backdrop-filter: blur(10px);
+    margin-left: 30px;
+    margin-right: 30px;
 }
 
 label, input, button {
@@ -107,12 +109,15 @@ button:hover {
 }
 
 .confirmation-message {
-    margin-top: 15px;
+    margin-top: 25px;
     padding: 12px;
     border-radius: 6px;
     text-align: center;
     font-weight: 500;
     animation: fadeIn 0.3s ease-in;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .confirmation-message.success {

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,14 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Plex Trakt Sync</title>
+    <title>PlexyTrack</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
 <div class="container">
-    <h1>Plex/Trakt Sync</h1>
+    <h1>PlexyTrack</h1>
+    <h2><em>Sync your Plex and Trakt libraries</em></h2>
     <form method="post" class="form-bordered">
         <label for="minutes">Sync every (minutes):</label>
         <input type="number" id="minutes" name="minutes" min="1" value="{{ minutes }}" class="input-bordered">


### PR DESCRIPTION
## Summary
- adjust layout margins so text has equal spacing left and right
- enlarge spacing before status messages and center them
- show new heading and subtitle
- disable collection sync by default

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6844698b7260832e86c4c1697b989a04