### PR TITLE
Add live sync via webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ If you mark a list as liked on Trakt, PlexyTrack will create a Plex collection w
 
 From the web interface you can download a backup file containing your Trakt history, watchlist and ratings. This JSON file can be uploaded again to restore your data at any time. Creating a backup is recommended before starting synchronization for the first time.
 
+### Live sync
+
+When **Live Sync** is enabled on the main page, PlexyTrack will start a
+webhook endpoint at `/webhook`. Configure a Plex Webhook to call this URL and
+the application will trigger an immediate sync whenever an event is received.
+
 ## Getting a Plex token
 
 1. Open the Plex Web application and sign in.

--- a/templates/index.html
+++ b/templates/index.html
@@ -51,6 +51,10 @@
                             <input type="checkbox" id="watchlists" name="watchlists" {% if watchlists %}checked{% endif %}>
                             <label for="watchlists">Watchlists</label>
                         </div>
+                        <div class="checkbox-group">
+                            <input type="checkbox" id="live_sync" name="live_sync" {% if live_sync %}checked{% endif %}>
+                            <label for="live_sync">Live Sync</label>
+                        </div>
                     </fieldset>
                     
                     <div class="form-actions">


### PR DESCRIPTION
## Summary
- add `LIVE_SYNC` flag and live webhook route
- toggle Live Sync from the sync settings UI
- document Live Sync in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6847dec02b24832eb21721f4480c0921