### PR TITLE
Add combined authorization for Trakt and Simkl

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ the application will trigger an immediate sync whenever an event is received.
 1. Log in to your Trakt account and open <https://trakt.tv/oauth/applications>.
 2. Create a new application. Any name will work and you can use `urn:ietf:wg:oauth:2.0:oob` as the redirect URL.
 3. After saving the app you will see a **Client ID** and **Client Secret**. Keep them handy.
-4. Start PlexyTrack and open `http://localhost:5000` in your browser. The page will provide a link to authorize the application on Trakt. After authorizing, paste the code shown by Trakt into the form. The app will handle exchanging the code for tokens automatically.
+4. Start PlexyTrack and open `http://localhost:5000` in your browser. The page will provide a link to authorize the application on Trakt. After authorizing, paste the code shown by Trakt into the form. If you also supplied Simkl credentials (`SIMKL_CLIENT_ID` and `SIMKL_CLIENT_SECRET`), the page will display authorization links for both platforms so you can enter both codes at once. The app will handle exchanging the codes for tokens automatically.
 
 
 ## Running with Docker Compose

--- a/app.py
+++ b/app.py
@@ -1458,9 +1458,45 @@ def index():
     load_simkl_tokens()
 
     # 1) Initial authorization
-    if SYNC_TO_TRAKT and (
+    trakt_creds = os.environ.get("TRAKT_CLIENT_ID") and os.environ.get("TRAKT_CLIENT_SECRET")
+    simkl_creds = os.environ.get("SIMKL_CLIENT_ID") and os.environ.get("SIMKL_CLIENT_SECRET")
+
+    trakt_missing = bool(trakt_creds) and (
         not os.environ.get("TRAKT_ACCESS_TOKEN") or not os.environ.get("TRAKT_REFRESH_TOKEN")
-    ):
+    )
+    simkl_missing = bool(simkl_creds) and not os.environ.get("SIMKL_ACCESS_TOKEN")
+
+    if trakt_missing and simkl_missing:
+        if request.method == "POST" and request.form.get("platform") == "both":
+            tcode = request.form.get("trakt_code", "").strip()
+            scode = request.form.get("simkl_code", "").strip()
+            success = True
+            if trakt_missing:
+                success = tcode and exchange_code_for_tokens(tcode)
+            if success and simkl_missing:
+                success = scode and exchange_simkl_code(scode)
+            if success:
+                start_scheduler()
+                return redirect(url_for("index"))
+        trakt_url = (
+            "https://trakt.tv/oauth/authorize"
+            f"?response_type=code&client_id={os.environ.get('TRAKT_CLIENT_ID')}"
+            f"&redirect_uri={TRAKT_REDIRECT_URI}"
+        )
+        simkl_url = (
+            "https://simkl.com/oauth/authorize"
+            f"?response_type=code&client_id={os.environ.get('SIMKL_CLIENT_ID')}"
+            f"&redirect_uri={SIMKL_REDIRECT_URI}"
+        )
+        return render_template(
+            "authorize_multi.html",
+            trakt_auth_url=trakt_url,
+            simkl_auth_url=simkl_url,
+            trakt_required=trakt_missing,
+            simkl_required=simkl_missing,
+        )
+
+    if trakt_missing:
         if request.method == "POST" and request.form.get("platform") == "trakt":
             code = request.form.get("code", "").strip()
             if code and exchange_code_for_tokens(code):
@@ -1473,7 +1509,7 @@ def index():
         )
         return render_template("authorize.html", auth_url=auth_url, platform="Trakt")
 
-    if SYNC_TO_SIMKL and not os.environ.get("SIMKL_ACCESS_TOKEN"):
+    if simkl_missing:
         if request.method == "POST" and request.form.get("platform") == "simkl":
             code = request.form.get("code", "").strip()
             if code and exchange_simkl_code(code):

--- a/templates/authorize_multi.html
+++ b/templates/authorize_multi.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PlexyTrack - Authorize Platforms</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <div class="app-container">
+        <header class="app-header">
+            <img src="{{ url_for('static', filename='logo.png') }}" alt="PlexyTrack Logo" class="logo">
+            <h1>PlexyTrack</h1>
+        </header>
+
+        <main class="content-area">
+            <section class="authorize-section card">
+                <h2>
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon"><path d="M12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2ZM11 11V7H13V11H17V13H13V17H11V13H7V11H11Z"></path></svg>
+                    Platforms Authorization Required
+                </h2>
+                <p class="description">Authorize PlexyTrack to access your accounts. Follow the links below and enter the PIN codes.</p>
+
+                <div class="auth-steps">
+                    {% if trakt_required %}
+                    <p>Authorize Trakt and copy the PIN code:</p>
+                    <a href="{{ trakt_auth_url }}" target="_blank" class="button primary auth-link">Go to Trakt</a>
+                    {% endif %}
+                    {% if simkl_required %}
+                    <p>Authorize Simkl and copy the PIN code:</p>
+                    <a href="{{ simkl_auth_url }}" target="_blank" class="button primary auth-link">Go to Simkl</a>
+                    {% endif %}
+                    <p>Enter the codes and submit:</p>
+                </div>
+
+                <form method="post" class="auth-form">
+                    <input type="hidden" name="platform" value="both">
+                    {% if trakt_required %}
+                    <div class="form-group">
+                        <label for="trakt_code">Trakt PIN Code:</label>
+                        <input type="text" id="trakt_code" name="trakt_code" placeholder="Enter Trakt PIN Code" class="form-input" required>
+                    </div>
+                    {% endif %}
+                    {% if simkl_required %}
+                    <div class="form-group">
+                        <label for="simkl_code">Simkl PIN Code:</label>
+                        <input type="text" id="simkl_code" name="simkl_code" placeholder="Enter Simkl PIN Code" class="form-input" required>
+                    </div>
+                    {% endif %}
+                    <button type="submit" class="button secondary">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon"><path d="M12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2ZM10.6212 15.5354L12.0354 16.9496L16.9496 12.0354L15.5354 10.6212L12.0354 14.1212L9.20702 11.2928L7.79281 12.707L10.6212 15.5354Z"></path></svg>
+                        Submit Codes
+                    </button>
+                </form>
+            </section>
+        </main>
+
+        <footer class="app-footer">
+            <p>&copy; 2025 PlexyTrack. All rights reserved.</p>
+        </footer>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support authorizing both platforms at once
- add new authorization template
- mention joint authorization in README
- detect Simkl credentials when deciding which auth page to show

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6847fdb978c8832e8fb7547c0d67cd80