### PR TITLE
Handle unexpected Simkl API responses

### DIFF
--- a/app.py
+++ b/app.py
@@ -557,6 +557,9 @@ def get_trakt_history(
             params={"page": page, "limit": 100},
         )
         data = resp.json()
+        if not isinstance(data, list):
+            logger.error("Unexpected Simkl history format: %r", data)
+            break
         if not data:
             break
         for item in data:
@@ -662,6 +665,9 @@ def get_simkl_history(
             params={"page": page, "limit": 100},
         )
         data = resp.json()
+        if not isinstance(data, list):
+            logger.error("Unexpected Simkl history format: %r", data)
+            break
         if not data:
             break
         for item in data:


### PR DESCRIPTION
## Summary
- handle non-list API responses when retrieving Simkl history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68485556db8c832eb5db4f7f4d183b73