### PR TITLE
Add provider selection toggle

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -170,6 +170,21 @@ body {
     margin-bottom: 0;
 }
 
+/* Provider toggle */
+.provider-toggle {
+    display: flex;
+    justify-content: center;
+    gap: 20px;
+    margin-bottom: 20px;
+}
+
+.provider-toggle label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 600;
+}
+
 /* Button Styles */
 .button {
     display: inline-flex;

--- a/templates/config.html
+++ b/templates/config.html
@@ -42,6 +42,29 @@
                 {% endif %}
                 <a href="{{ url_for('authorize_service', service='simkl') }}" class="button primary" style="margin-top:10px;">Configure</a>
             </section>
+
+            <section class="card">
+                <h2>Select Provider</h2>
+                <form method="post" class="provider-form">
+                    <div class="provider-toggle">
+                        <label>
+                            <input type="radio" name="provider" value="trakt" {% if provider == 'trakt' %}checked{% endif %}>
+                            Trakt
+                        </label>
+                        <label>
+                            <input type="radio" name="provider" value="none" {% if provider == 'none' %}checked{% endif %}>
+                            None
+                        </label>
+                        <label>
+                            <input type="radio" name="provider" value="simkl" {% if provider == 'simkl' %}checked{% endif %}>
+                            Simkl
+                        </label>
+                    </div>
+                    <div class="form-actions">
+                        <button type="submit" class="button primary">Save</button>
+                    </div>
+                </form>
+            </section>
         </main>
 
         <footer class="app-footer">


### PR DESCRIPTION
## Summary
- support selecting a single sync provider
- load/save provider in `provider.json`
- add 3-way toggle on configuration page
- style provider toggle

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684893a01590832e928e9b6e026a845e