### PR TITLE
Fix Simkl list sync error when API returns empty body

### DIFF
--- a/app.py
+++ b/app.py
@@ -1361,8 +1361,15 @@ def sync_collections_to_simkl(plex, headers):
     """Create or update Simkl lists from Plex collections."""
     try:
         user_data = simkl_request("GET", "/users/settings", headers).json()
-        username = user_data.get("user", {}).get("username") or user_data.get("user", {}).get("ids", {}).get("slug")
-        lists = simkl_request("GET", f"/users/{username}/lists", headers).json()
+        username = (
+            user_data.get("user", {}).get("username")
+            or user_data.get("user", {}).get("ids", {}).get("slug")
+        )
+        resp = simkl_request("GET", f"/users/{username}/lists", headers)
+        lists = resp.json()
+        if not isinstance(lists, list):
+            logger.error("Unexpected response when fetching Simkl lists: %s", lists)
+            return
     except Exception as exc:
         logger.error("Failed to fetch Simkl lists: %s", exc)
         return


### PR DESCRIPTION
## Summary
- prevent `NoneType` errors when retrieving Simkl lists

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6848a150d4c8832ead8cb87db905f14e