### PR TITLE
Remove undocumented list endpoint usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ If you don't already have the Trakt or Simkl credentials, please see the next se
 
 ### Collections and watchlists
 
-If you mark a list as liked on Trakt, PlexyTrack will create a Plex collection with the same name and add the matching movies or shows found in your library. Likewise, any collection created in Plex will be mirrored as a list on Trakt. Watchlists are also kept in sync both ways, so adding or removing an item in one platform is reflected in the other.
-When the Simkl provider is selected, your Plex library is copied to the **My TV Shows** and **My Movies** sections on Simkl and Plex collections are mirrored as Simkl lists.
+If you mark a list as liked on Trakt, PlexyTrack will create a Plex collection with the same name and add the matching movies or shows found in your library. Watchlists are also kept in sync both ways, so adding or removing an item in one platform is reflected in the other.
+When the Simkl provider is selected, your Plex library is copied to the **My TV Shows** and **My Movies** sections on Simkl.
 
 ### Backup and restore
 


### PR DESCRIPTION
## Summary
- avoid `/users/{name}/lists/{slug}/items` and similar paths
- drop custom list syncing functions
- update docs

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6848d64497c0832e87e5419fb482ad42