### PR TITLE
Disable Sync options for Simkl

### DIFF
--- a/app.py
+++ b/app.py
@@ -1752,6 +1752,13 @@ def index():
         SYNC_LIKED_LISTS = request.form.get("liked_lists") is not None
         SYNC_WATCHLISTS = request.form.get("watchlists") is not None
         LIVE_SYNC = request.form.get("live_sync") is not None
+
+        if SYNC_PROVIDER == "simkl":
+            SYNC_COLLECTION = False
+            SYNC_RATINGS = False
+            SYNC_LIKED_LISTS = False
+            SYNC_WATCHLISTS = False
+            LIVE_SYNC = False
         
         # Only start scheduler when manually requested from sync tab
         start_scheduler()
@@ -1779,6 +1786,7 @@ def index():
         liked_lists=SYNC_LIKED_LISTS,
         watchlists=SYNC_WATCHLISTS,
         live_sync=LIVE_SYNC,
+        provider=SYNC_PROVIDER,
         message=message,
         mtype=mtype,
         next_run=next_run,

--- a/static/style.css
+++ b/static/style.css
@@ -170,6 +170,10 @@ body {
     margin-bottom: 0;
 }
 
+.checkbox-group input[type="checkbox"]:disabled + label {
+    color: #888;
+}
+
 /* Provider toggle */
 .provider-toggle {
     display: flex;

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,11 +34,11 @@
                     <fieldset class="sync-options">
                         <legend>Sync Options</legend>
                         <div class="checkbox-group">
-                            <input type="checkbox" id="collection" name="collection" {% if collection %}checked{% endif %}>
+                            <input type="checkbox" id="collection" name="collection" {% if collection %}checked{% endif %} {% if provider == 'simkl' %}disabled{% endif %}>
                             <label for="collection">Collection</label>
                         </div>
                         <div class="checkbox-group">
-                            <input type="checkbox" id="ratings" name="ratings" {% if ratings %}checked{% endif %}>
+                            <input type="checkbox" id="ratings" name="ratings" {% if ratings %}checked{% endif %} {% if provider == 'simkl' %}disabled{% endif %}>
                             <label for="ratings">Ratings</label>
                         </div>
                         <div class="checkbox-group">
@@ -46,15 +46,15 @@
                             <label for="watched">Watched History</label>
                         </div>
                         <div class="checkbox-group">
-                            <input type="checkbox" id="liked_lists" name="liked_lists" {% if liked_lists %}checked{% endif %}>
+                            <input type="checkbox" id="liked_lists" name="liked_lists" {% if liked_lists %}checked{% endif %} {% if provider == 'simkl' %}disabled{% endif %}>
                             <label for="liked_lists">Liked Lists</label>
                         </div>
                         <div class="checkbox-group">
-                            <input type="checkbox" id="watchlists" name="watchlists" {% if watchlists %}checked{% endif %}>
+                            <input type="checkbox" id="watchlists" name="watchlists" {% if watchlists %}checked{% endif %} {% if provider == 'simkl' %}disabled{% endif %}>
                             <label for="watchlists">Watchlists</label>
                         </div>
                         <div class="checkbox-group">
-                            <input type="checkbox" id="live_sync" name="live_sync" {% if live_sync %}checked{% endif %}>
+                            <input type="checkbox" id="live_sync" name="live_sync" {% if live_sync %}checked{% endif %} {% if provider == 'simkl' %}disabled{% endif %}>
                             <label for="live_sync">Live Sync</label>
                         </div>
                     </fieldset>


### PR DESCRIPTION
## Summary
- disable Collection, Ratings, Liked Lists, Watchlists and Live Sync checkboxes when Simkl is the provider
- grey out disabled options in CSS
- ensure backend ignores those options and pass provider to template

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b222e73c4832e81b250f61d29ae82