### PR TITLE
Handle Unauthorized errors when fetching Plex history

### DIFF
--- a/plex_utils.py
+++ b/plex_utils.py
@@ -6,6 +6,7 @@ from typing import Dict, Optional, Set, Tuple, List
 import requests
 
 from plexapi.server import PlexServer
+from plexapi.exceptions import Unauthorized
 
 from utils import (
     _parse_guid_value,
@@ -117,7 +118,13 @@ def get_plex_history(plex, accounts: Optional[List[str]] = None) -> Tuple[
         episodes: Dict[str, Dict[str, Optional[str]]] = {}
         show_guid_cache: Dict[str, Optional[str]] = {}
 
-        for entry in server.history():
+        try:
+            history_entries = server.history()
+        except Unauthorized as exc:
+            logger.warning("Failed to access Plex history: %s", exc)
+            return movies, episodes
+
+        for entry in history_entries:
             watched_at = to_iso_z(getattr(entry, "viewedAt", None))
 
             if entry.type == "movie":
@@ -183,7 +190,13 @@ def get_plex_history(plex, accounts: Optional[List[str]] = None) -> Tuple[
                     }
 
         logger.info("Fetching watched flags from Plex library…")
-        for section in server.library.sections():
+        try:
+            sections = server.library.sections()
+        except Unauthorized as exc:
+            logger.warning("Failed to access Plex library: %s", exc)
+            return movies, episodes
+
+        for section in sections:
             try:
                 if section.type == "movie":
                     for item in section.search(viewCount__gt=0):


### PR DESCRIPTION
## Summary
- handle `Unauthorized` exceptions when fetching Plex history
- catch `Unauthorized` when accessing library sections

## Testing
- `python -m py_compile plex_utils.py app.py utils.py trakt_utils.py simkl_utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_684f1d8a4a30832e9ea9c77e42a1df59