### PR TITLE
Add Migration tab and bump API version

### DIFF
--- a/app.py
+++ b/app.py
@@ -108,7 +108,7 @@ werkzeug_logger.setLevel(logging.WARNING)
 # APPLICATION INFO
 # --------------------------------------------------------------------------- #
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.3.5"
+APP_VERSION = "v0.3.6"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 
 # --------------------------------------------------------------------------- #
@@ -2599,8 +2599,9 @@ def restore_backup_route():
     return redirect(url_for("backup_page", message="Backup restored", mtype="success"))
 
 
+@app.route("/migration", methods=["GET", "POST"])
 @app.route("/service_sync", methods=["GET", "POST"])
-def service_sync_page():
+def migration_page():
     """Synchronize history between Trakt and Simkl."""
     load_trakt_tokens()
     load_simkl_tokens()
@@ -2676,7 +2677,7 @@ def service_sync_page():
             message = "Invalid sync direction"
             mtype = "error"
 
-    return render_template("service_sync.html", message=message, mtype=mtype)
+    return render_template("migration.html", message=message, mtype=mtype)
 
 
 @app.route("/webhook", methods=["POST"])

--- a/simkl_utils.py
+++ b/simkl_utils.py
@@ -10,7 +10,7 @@ from utils import guid_to_ids, normalize_year, simkl_episode_key, to_iso_z
 logger = logging.getLogger(__name__)
 
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.3.5"
+APP_VERSION = "v0.3.6"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 
 SIMKL_TOKEN_FILE = "simkl_tokens.json"

--- a/templates/authorize.html
+++ b/templates/authorize.html
@@ -16,7 +16,7 @@
             <button class="nav-toggle" id="navToggle">&#9776;</button>
             <nav class="app-nav">
                 <a href="{{ url_for('index') }}" class="nav-link">Sync</a>
-                <a href="{{ url_for('service_sync_page') }}" class="nav-link">Service Sync</a>
+                <a href="{{ url_for('migration_page') }}" class="nav-link">Migration</a>
                 <a href="{{ url_for('backup_page') }}" class="nav-link">Backup</a>
                 <a href="{{ url_for('config_page') }}" class="nav-link active">Config.</a>
                 <a href="{{ url_for('users_page') }}" class="nav-link">Users</a>

--- a/templates/backup.html
+++ b/templates/backup.html
@@ -17,7 +17,7 @@
             <button class="nav-toggle" id="navToggle">&#9776;</button>
             <nav class="app-nav">
                 <a href="{{ url_for('index') }}" class="nav-link">Sync</a>
-                <a href="{{ url_for('service_sync_page') }}" class="nav-link">Service Sync</a>
+                <a href="{{ url_for('migration_page') }}" class="nav-link">Migration</a>
                 <a href="{{ url_for('backup_page') }}" class="nav-link active">Backup</a>
                 <a href="{{ url_for('config_page') }}" class="nav-link">Config.</a>
                 <a href="{{ url_for('users_page') }}" class="nav-link">Users</a>

--- a/templates/config.html
+++ b/templates/config.html
@@ -17,7 +17,7 @@
             <button class="nav-toggle" id="navToggle">&#9776;</button>
             <nav class="app-nav">
                 <a href="{{ url_for('index') }}" class="nav-link">Sync</a>
-                <a href="{{ url_for('service_sync_page') }}" class="nav-link">Service Sync</a>
+                <a href="{{ url_for('migration_page') }}" class="nav-link">Migration</a>
                 <a href="{{ url_for('backup_page') }}" class="nav-link">Backup</a>
                 <a href="{{ url_for('config_page') }}" class="nav-link active">Config.</a>
                 <a href="{{ url_for('users_page') }}" class="nav-link">Users</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -91,7 +91,7 @@
             <button class="nav-toggle" id="navToggle">&#9776;</button>
             <nav class="app-nav">
                 <a href="{{ url_for('index') }}" class="nav-link active">Sync</a>
-                <a href="{{ url_for('service_sync_page') }}" class="nav-link">Service Sync</a>
+                <a href="{{ url_for('migration_page') }}" class="nav-link">Migration</a>
                 <a href="{{ url_for('backup_page') }}" class="nav-link">Backup</a>
                 <a href="{{ url_for('config_page') }}" class="nav-link">Config.</a>
                 <a href="{{ url_for('users_page') }}" class="nav-link">Users</a>

--- a/templates/migration.html
+++ b/templates/migration.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>PlexyTrack - Service Sync</title>
+    <title>PlexyTrack - Migration</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
@@ -16,7 +16,7 @@
             <h1>PlexyTrack</h1>
             <nav class="app-nav">
                 <a href="{{ url_for('index') }}" class="nav-link">Sync</a>
-                <a href="{{ url_for('service_sync_page') }}" class="nav-link active">Service Sync</a>
+                <a href="{{ url_for('migration_page') }}" class="nav-link active">Migration</a>
                 <a href="{{ url_for('backup_page') }}" class="nav-link">Backup</a>
                 <a href="{{ url_for('config_page') }}" class="nav-link">Config.</a>
                 <a href="{{ url_for('users_page') }}" class="nav-link">Users</a>

--- a/templates/oauth.html
+++ b/templates/oauth.html
@@ -17,7 +17,7 @@
             <button class="nav-toggle" id="navToggle">&#9776;</button>
             <nav class="app-nav">
                 <a href="{{ url_for('index') }}" class="nav-link">Sync</a>
-                <a href="{{ url_for('service_sync_page') }}" class="nav-link">Service Sync</a>
+                <a href="{{ url_for('migration_page') }}" class="nav-link">Migration</a>
                 <a href="{{ url_for('backup_page') }}" class="nav-link">Backup</a>
                 <a href="{{ url_for('config_page') }}" class="nav-link">Config.</a>
                 <a href="{{ url_for('users_page') }}" class="nav-link">Users</a>

--- a/templates/users.html
+++ b/templates/users.html
@@ -182,7 +182,7 @@
             <button class="nav-toggle" id="navToggle">&#9776;</button>
             <nav class="app-nav">
                 <a href="{{ url_for('index') }}" class="nav-link">Sync</a>
-                <a href="{{ url_for('service_sync_page') }}" class="nav-link">Service Sync</a>
+                <a href="{{ url_for('migration_page') }}" class="nav-link">Migration</a>
                 <a href="{{ url_for('backup_page') }}" class="nav-link">Backup</a>
                 <a href="{{ url_for('config_page') }}" class="nav-link">Config.</a>
                 <a href="{{ url_for('users_page') }}" class="nav-link active">Users</a>

--- a/trakt_utils.py
+++ b/trakt_utils.py
@@ -12,7 +12,7 @@ from utils import guid_to_ids, normalize_year, to_iso_z, valid_guid, best_guid, 
 logger = logging.getLogger(__name__)
 
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.3.5"
+APP_VERSION = "v0.3.6"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 
 TOKEN_FILE = "trakt_tokens.json"


### PR DESCRIPTION
## Summary
- add migration tab and page for transferring watch history between Trakt and Simkl
- update application API version to v0.3.6

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890839bb47c832eb1e2dae928718df0