### PR TITLE
Move header menus to sidebar and enhance layout responsiveness

### DIFF
--- a/static/logout.js
+++ b/static/logout.js
@@ -17,10 +17,10 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     const navToggle = document.getElementById('navToggle');
-    const appNav = document.querySelector('.app-nav');
-    if (navToggle && appNav) {
+    const sidebar = document.querySelector('.sidebar');
+    if (navToggle && sidebar) {
         navToggle.addEventListener('click', function() {
-            appNav.classList.toggle('open');
+            sidebar.classList.toggle('open');
         });
     }
 });

--- a/static/style.css
+++ b/static/style.css
@@ -6,21 +6,43 @@ body {
     margin: 0;
     padding: 0;
     display: flex;
-    justify-content: center;
-    align-items: flex-start;
     min-height: 100vh;
     line-height: 1.6;
 }
 
 /* App Container */
 .app-container {
+    flex: 1;
     width: 100%;
-    max-width: 900px;
-    margin: 20px;
+    margin: 0;
     background-color: #ffffff;
     border-radius: 12px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
     overflow: hidden;
+}
+
+/* Sidebar */
+.sidebar {
+    background-color: #2c3e50;
+    color: #ecf0f1;
+    width: 220px;
+    padding: 20px 15px;
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+    min-height: 100vh;
+}
+
+.sidebar .logo {
+    height: 50px;
+    width: auto;
+    margin: 0 auto 20px auto;
+}
+
+.sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
 }
 
 /* App Header */
@@ -57,12 +79,6 @@ body {
     cursor: pointer;
 }
 
-/* Navigation */
-.app-nav {
-    display: flex;
-    gap: 15px;
-}
-
 .nav-link {
     color: #ecf0f1;
     text-decoration: none;
@@ -91,44 +107,33 @@ body {
     border-radius: 4px;
     cursor: pointer;
     font-size: 14px;
-    margin-left: 20px;
 }
 
 .btn-logout:hover {
     background: #c82333;
 }
 
-/* Responsive Navigation (Mobile) */
+/* Responsive Sidebar (Mobile) */
 @media (max-width: 768px) {
-    .nav-toggle {
-        display: block;
-    }
-
-    .app-nav {
-        display: none;
+    body {
         flex-direction: column;
-        gap: 0;
-        position: absolute;
-        top: 100%;
-        left: 0;
-        width: 100%;
-        background-color: #2c3e50;
-        padding: 10px 0;
-        z-index: 1000;
     }
 
-    .app-nav.open {
+    .sidebar {
+        width: 100%;
+        display: none;
+    }
+
+    .sidebar.open {
         display: flex;
     }
 
-    .app-nav .nav-link,
-    .app-nav .btn-logout {
-        margin: 0;
-        padding: 10px 20px;
+    .app-container {
+        width: 100%;
     }
 
-    .app-nav .btn-logout {
-        margin-left: 0;
+    .nav-toggle {
+        display: block;
     }
 }
 
@@ -512,18 +517,6 @@ form button[type="submit"],
         position: absolute;
         top: 20px;
         right: 20px;
-    }
-
-    .app-nav {
-        display: none;
-        flex-direction: column;
-        gap: 10px;
-        margin-top: 15px;
-        width: 100%;
-    }
-
-    .app-nav.open {
-        display: flex;
     }
 
     .content-area {

--- a/templates/authorize.html
+++ b/templates/authorize.html
@@ -9,20 +9,22 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
+    <aside class="sidebar">
+        <img src="{{ url_for('static', filename='logo.png') }}" alt="PlexyTrack Logo" class="logo">
+        <nav class="sidebar-nav">
+            <a href="{{ url_for('index') }}" class="nav-link">Sync</a>
+            <a href="{{ url_for('migration_page') }}" class="nav-link">Migration</a>
+            <a href="{{ url_for('backup_page') }}" class="nav-link">Backup</a>
+            <a href="{{ url_for('config_page') }}" class="nav-link active">Config.</a>
+            <a href="{{ url_for('users_page') }}" class="nav-link">Users</a>
+            <a href="{{ url_for('oauth_index') }}" class="nav-link">OAuth</a>
+            <button id="logoutBtn" class="btn-logout">Log Out</button>
+        </nav>
+    </aside>
     <div class="app-container">
         <header class="app-header">
-            <img src="{{ url_for('static', filename='logo.png') }}" alt="PlexyTrack Logo" class="logo">
-            <h1>PlexyTrack</h1>
             <button class="nav-toggle" id="navToggle">&#9776;</button>
-            <nav class="app-nav">
-                <a href="{{ url_for('index') }}" class="nav-link">Sync</a>
-                <a href="{{ url_for('migration_page') }}" class="nav-link">Migration</a>
-                <a href="{{ url_for('backup_page') }}" class="nav-link">Backup</a>
-                <a href="{{ url_for('config_page') }}" class="nav-link active">Config.</a>
-                <a href="{{ url_for('users_page') }}" class="nav-link">Users</a>
-                <a href="{{ url_for('oauth_index') }}" class="nav-link">OAuth</a>
-                <button id="logoutBtn" class="btn-logout">Log Out</button>
-            </nav>
+            <h1>PlexyTrack</h1>
         </header>
 
         <main class="content-area">

--- a/templates/backup.html
+++ b/templates/backup.html
@@ -10,20 +10,22 @@
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
 </head>
 <body>
+    <aside class="sidebar">
+        <img src="{{ url_for('static', filename='logo.png') }}" alt="PlexyTrack Logo" class="logo">
+        <nav class="sidebar-nav">
+            <a href="{{ url_for('index') }}" class="nav-link">Sync</a>
+            <a href="{{ url_for('migration_page') }}" class="nav-link">Migration</a>
+            <a href="{{ url_for('backup_page') }}" class="nav-link active">Backup</a>
+            <a href="{{ url_for('config_page') }}" class="nav-link">Config.</a>
+            <a href="{{ url_for('users_page') }}" class="nav-link">Users</a>
+            <a href="{{ url_for('oauth_index') }}" class="nav-link">OAuth</a>
+            <button id="logoutBtn" class="btn-logout">Log Out</button>
+        </nav>
+    </aside>
     <div class="app-container">
         <header class="app-header">
-            <img src="{{ url_for('static', filename='logo.png') }}" alt="PlexyTrack Logo" class="logo">
-            <h1>PlexyTrack</h1>
             <button class="nav-toggle" id="navToggle">&#9776;</button>
-            <nav class="app-nav">
-                <a href="{{ url_for('index') }}" class="nav-link">Sync</a>
-                <a href="{{ url_for('migration_page') }}" class="nav-link">Migration</a>
-                <a href="{{ url_for('backup_page') }}" class="nav-link active">Backup</a>
-                <a href="{{ url_for('config_page') }}" class="nav-link">Config.</a>
-                <a href="{{ url_for('users_page') }}" class="nav-link">Users</a>
-                <a href="{{ url_for('oauth_index') }}" class="nav-link">OAuth</a>
-                <button id="logoutBtn" class="btn-logout">Log Out</button>
-            </nav>
+            <h1>PlexyTrack</h1>
         </header>
 
         <main class="content-area">

--- a/templates/config.html
+++ b/templates/config.html
@@ -10,20 +10,22 @@
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
 </head>
 <body>
+    <aside class="sidebar">
+        <img src="{{ url_for('static', filename='logo.png') }}" alt="PlexyTrack Logo" class="logo">
+        <nav class="sidebar-nav">
+            <a href="{{ url_for('index') }}" class="nav-link">Sync</a>
+            <a href="{{ url_for('migration_page') }}" class="nav-link">Migration</a>
+            <a href="{{ url_for('backup_page') }}" class="nav-link">Backup</a>
+            <a href="{{ url_for('config_page') }}" class="nav-link active">Config.</a>
+            <a href="{{ url_for('users_page') }}" class="nav-link">Users</a>
+            <a href="{{ url_for('oauth_index') }}" class="nav-link">OAuth</a>
+            <button id="logoutBtn" class="btn-logout">Log Out</button>
+        </nav>
+    </aside>
     <div class="app-container">
         <header class="app-header">
-            <img src="{{ url_for('static', filename='logo.png') }}" alt="PlexyTrack Logo" class="logo">
-            <h1>PlexyTrack</h1>
             <button class="nav-toggle" id="navToggle">&#9776;</button>
-            <nav class="app-nav">
-                <a href="{{ url_for('index') }}" class="nav-link">Sync</a>
-                <a href="{{ url_for('migration_page') }}" class="nav-link">Migration</a>
-                <a href="{{ url_for('backup_page') }}" class="nav-link">Backup</a>
-                <a href="{{ url_for('config_page') }}" class="nav-link active">Config.</a>
-                <a href="{{ url_for('users_page') }}" class="nav-link">Users</a>
-                <a href="{{ url_for('oauth_index') }}" class="nav-link">OAuth</a>
-                <button id="logoutBtn" class="btn-logout">Log Out</button>
-            </nav>
+            <h1>PlexyTrack</h1>
         </header>
 
         <main class="content-area">

--- a/templates/index.html
+++ b/templates/index.html
@@ -84,20 +84,22 @@
     </style>
 </head>
 <body>
+    <aside class="sidebar">
+        <img src="{{ url_for('static', filename='logo.png') }}" alt="PlexyTrack Logo" class="logo">
+        <nav class="sidebar-nav">
+            <a href="{{ url_for('index') }}" class="nav-link active">Sync</a>
+            <a href="{{ url_for('migration_page') }}" class="nav-link">Migration</a>
+            <a href="{{ url_for('backup_page') }}" class="nav-link">Backup</a>
+            <a href="{{ url_for('config_page') }}" class="nav-link">Config.</a>
+            <a href="{{ url_for('users_page') }}" class="nav-link">Users</a>
+            <a href="{{ url_for('oauth_index') }}" class="nav-link">OAuth</a>
+            <button id="logoutBtn" class="btn-logout">Log Out</button>
+        </nav>
+    </aside>
     <div class="app-container">
         <header class="app-header">
-            <img src="{{ url_for('static', filename='logo.png') }}" alt="PlexyTrack Logo" class="logo">
-            <h1>PlexyTrack</h1>
             <button class="nav-toggle" id="navToggle">&#9776;</button>
-            <nav class="app-nav">
-                <a href="{{ url_for('index') }}" class="nav-link active">Sync</a>
-                <a href="{{ url_for('migration_page') }}" class="nav-link">Migration</a>
-                <a href="{{ url_for('backup_page') }}" class="nav-link">Backup</a>
-                <a href="{{ url_for('config_page') }}" class="nav-link">Config.</a>
-                <a href="{{ url_for('users_page') }}" class="nav-link">Users</a>
-                <a href="{{ url_for('oauth_index') }}" class="nav-link">OAuth</a>
-                <button id="logoutBtn" class="btn-logout">Log Out</button>
-            </nav>
+            <h1>PlexyTrack</h1>
         </header>
 
         <main class="content-area">

--- a/templates/migration.html
+++ b/templates/migration.html
@@ -10,19 +10,22 @@
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
 </head>
 <body>
+    <aside class="sidebar">
+        <img src="{{ url_for('static', filename='logo.png') }}" alt="PlexyTrack Logo" class="logo">
+        <nav class="sidebar-nav">
+            <a href="{{ url_for('index') }}" class="nav-link">Sync</a>
+            <a href="{{ url_for('migration_page') }}" class="nav-link active">Migration</a>
+            <a href="{{ url_for('backup_page') }}" class="nav-link">Backup</a>
+            <a href="{{ url_for('config_page') }}" class="nav-link">Config.</a>
+            <a href="{{ url_for('users_page') }}" class="nav-link">Users</a>
+            <a href="{{ url_for('oauth_index') }}" class="nav-link">OAuth</a>
+            <button id="logoutBtn" class="btn-logout">Log Out</button>
+        </nav>
+    </aside>
     <div class="app-container">
         <header class="app-header">
-            <img src="{{ url_for('static', filename='logo.png') }}" alt="PlexyTrack Logo" class="logo">
+            <button class="nav-toggle" id="navToggle">&#9776;</button>
             <h1>PlexyTrack</h1>
-            <nav class="app-nav">
-                <a href="{{ url_for('index') }}" class="nav-link">Sync</a>
-                <a href="{{ url_for('migration_page') }}" class="nav-link active">Migration</a>
-                <a href="{{ url_for('backup_page') }}" class="nav-link">Backup</a>
-                <a href="{{ url_for('config_page') }}" class="nav-link">Config.</a>
-                <a href="{{ url_for('users_page') }}" class="nav-link">Users</a>
-                <a href="{{ url_for('oauth_index') }}" class="nav-link">OAuth</a>
-                <button id="logoutBtn" class="btn-logout">Log Out</button>
-            </nav>
         </header>
 
         <main class="content-area">

--- a/templates/oauth.html
+++ b/templates/oauth.html
@@ -10,20 +10,22 @@
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='logo.png') }}">
 </head>
 <body>
+    <aside class="sidebar">
+        <img src="{{ url_for('static', filename='logo.png') }}" alt="PlexyTrack Logo" class="logo">
+        <nav class="sidebar-nav">
+            <a href="{{ url_for('index') }}" class="nav-link">Sync</a>
+            <a href="{{ url_for('migration_page') }}" class="nav-link">Migration</a>
+            <a href="{{ url_for('backup_page') }}" class="nav-link">Backup</a>
+            <a href="{{ url_for('config_page') }}" class="nav-link">Config.</a>
+            <a href="{{ url_for('users_page') }}" class="nav-link">Users</a>
+            <a href="{{ url_for('oauth_index') }}" class="nav-link active">OAuth</a>
+            <button id="logoutBtn" class="btn-logout">Log Out</button>
+        </nav>
+    </aside>
     <div class="app-container">
         <header class="app-header">
-            <img src="{{ url_for('static', filename='logo.png') }}" alt="PlexyTrack Logo" class="logo">
-            <h1>PlexyTrack</h1>
             <button class="nav-toggle" id="navToggle">&#9776;</button>
-            <nav class="app-nav">
-                <a href="{{ url_for('index') }}" class="nav-link">Sync</a>
-                <a href="{{ url_for('migration_page') }}" class="nav-link">Migration</a>
-                <a href="{{ url_for('backup_page') }}" class="nav-link">Backup</a>
-                <a href="{{ url_for('config_page') }}" class="nav-link">Config.</a>
-                <a href="{{ url_for('users_page') }}" class="nav-link">Users</a>
-                <a href="{{ url_for('oauth_index') }}" class="nav-link active">OAuth</a>
-                <button id="logoutBtn" class="btn-logout">Log Out</button>
-            </nav>
+            <h1>PlexyTrack</h1>
         </header>
 
         <main class="content-area">

--- a/templates/users.html
+++ b/templates/users.html
@@ -175,20 +175,22 @@
     </style>
 </head>
 <body>
+    <aside class="sidebar">
+        <img src="{{ url_for('static', filename='logo.png') }}" alt="PlexyTrack Logo" class="logo">
+        <nav class="sidebar-nav">
+            <a href="{{ url_for('index') }}" class="nav-link">Sync</a>
+            <a href="{{ url_for('migration_page') }}" class="nav-link">Migration</a>
+            <a href="{{ url_for('backup_page') }}" class="nav-link">Backup</a>
+            <a href="{{ url_for('config_page') }}" class="nav-link">Config.</a>
+            <a href="{{ url_for('users_page') }}" class="nav-link active">Users</a>
+            <a href="{{ url_for('oauth_index') }}" class="nav-link">OAuth</a>
+            <button id="logoutBtn" class="btn-logout">Log Out</button>
+        </nav>
+    </aside>
     <div class="app-container">
         <header class="app-header">
-            <img src="{{ url_for('static', filename='logo.png') }}" alt="PlexyTrack Logo" class="logo">
-            <h1>PlexyTrack</h1>
             <button class="nav-toggle" id="navToggle">&#9776;</button>
-            <nav class="app-nav">
-                <a href="{{ url_for('index') }}" class="nav-link">Sync</a>
-                <a href="{{ url_for('migration_page') }}" class="nav-link">Migration</a>
-                <a href="{{ url_for('backup_page') }}" class="nav-link">Backup</a>
-                <a href="{{ url_for('config_page') }}" class="nav-link">Config.</a>
-                <a href="{{ url_for('users_page') }}" class="nav-link active">Users</a>
-                <a href="{{ url_for('oauth_index') }}" class="nav-link">OAuth</a>
-                <button id="logoutBtn" class="btn-logout">Log Out</button>
-            </nav>
+            <h1>PlexyTrack</h1>
         </header>
 
         <main class="content-area">
@@ -762,7 +764,6 @@
                 e.preventDefault();
             }
         });
-    </script>
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Relocate navigation links from top header to a new left sidebar across pages
- Simplify body layout and add mobile-responsive sidebar toggle for compact devices
- Adjust styles for full-width content with minimal margins

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68908e9abea4832eaddb238798db47da