### PR TITLE
Add Simkl ratings sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
   <img src="static/logo2.png" alt="PlexyTrack Logo" width="200" />
 </p>
 
-This project synchronizes your Plex library with Trakt. Besides watched history it can optionally add items to your Trakt collection, sync ratings and watchlists, and now mirrors Trakt lists you like as Plex collections. Collections created in Plex will in turn appear as Trakt lists. A small Flask web interface lets you choose which features to enable and configure the sync interval. Items that are manually marked as watched in Plex are detected as well. The interface also includes a tool for creating backups of your history, watchlist and ratings.
+This project synchronizes your Plex library with Trakt or Simkl. Besides watched history it can optionally add items to your Trakt collection, sync ratings and watchlists, and now mirrors Trakt lists you like as Plex collections. Collections created in Plex will in turn appear as Trakt lists. A small Flask web interface lets you choose which features to enable and configure the sync interval. Items that are manually marked as watched in Plex are detected as well. The interface also includes a tool for creating backups of your history, watchlist and ratings.
 The recommended sync interval is **at least 60 minutes**. Shorter intervals generally do not provide any benefit, and you can even synchronize once every 24 hours to reduce the load on your server and the API.
 
 ## Features
 
 - Bidirectional sync of watched history between Plex and Trakt or Simkl
-- Optional synchronization of ratings, collections, liked lists and watchlists
+- Optional synchronization of ratings, collections, liked lists and watchlists (ratings supported for both Trakt and Simkl; Simkl accepts movies and shows only)
 - Live Sync mode to trigger updates immediately from Plex webhooks
 - Simple backup and restore of all your Trakt data from the web interface
 - Intuitive UI for configuration and user selection

--- a/app.py
+++ b/app.py
@@ -86,6 +86,8 @@ from simkl_utils import (
     simkl_request,
     get_simkl_history,
     update_simkl,
+    sync_simkl_ratings,
+    apply_simkl_ratings,
 )
 
 # --------------------------------------------------------------------------- #
@@ -2189,7 +2191,10 @@ def sync():
                 return
             sync_ratings(plex, headers)
         elif SYNC_PROVIDER == "simkl":
-            logger.warning("Ratings sync with Simkl is not yet supported.")
+            if stop_event.is_set():
+                logger.info("Sync cancelled")
+                return
+            sync_simkl_ratings(plex, headers)
 
     if SYNC_RATINGS and RATINGS_SYNC_DIRECTION in (DIRECTION_BOTH, DIRECTION_SERVICE_TO_PLEX):
         if SYNC_PROVIDER == "trakt" and selected_user.get("is_owner", False):
@@ -2197,8 +2202,11 @@ def sync():
                 logger.info("Sync cancelled")
                 return
             apply_trakt_ratings(plex, headers)
-        elif SYNC_PROVIDER == "simkl":
-            logger.warning("Ratings import from Simkl is not yet supported.")
+        elif SYNC_PROVIDER == "simkl" and selected_user.get("is_owner", False):
+            if stop_event.is_set():
+                logger.info("Sync cancelled")
+                return
+            apply_simkl_ratings(plex, headers)
 
     if SYNC_WATCHLISTS and SYNC_PROVIDER == "trakt":
         if stop_event.is_set():
@@ -2430,7 +2438,6 @@ def index():
 
         if SYNC_PROVIDER == "simkl":
             SYNC_COLLECTION = False
-            SYNC_RATINGS = False
             SYNC_LIKED_LISTS = False
             SYNC_WATCHLISTS = False
             LIVE_SYNC = False
@@ -2472,7 +2479,6 @@ def index():
 
     if SYNC_PROVIDER == "simkl":
         display_collection = False
-        display_ratings = False
         display_liked_lists = False
         display_watchlists = False
         display_live_sync = False
@@ -2546,7 +2552,6 @@ def sync_once():
 
     if SYNC_PROVIDER == "simkl":
         SYNC_COLLECTION = False
-        SYNC_RATINGS = False
         SYNC_LIKED_LISTS = False
         SYNC_WATCHLISTS = False
         LIVE_SYNC = False

--- a/templates/index.html
+++ b/templates/index.html
@@ -131,7 +131,7 @@
                             </select>
                         </div>
                         <div class="checkbox-group">
-                            <input type="checkbox" id="ratings" name="ratings" {% if ratings %}checked{% endif %} {% if provider == 'simkl' %}disabled{% endif %}>
+                            <input type="checkbox" id="ratings" name="ratings" {% if ratings %}checked{% endif %}>
                             <label for="ratings">Ratings</label>
                             <select id="ratings_direction" name="ratings_direction" class="direction-select">
                                 <option value="both" {% if ratings_direction == 'both' %}selected{% endif %}>Bidirectional</option>


### PR DESCRIPTION
## Summary
- support syncing Plex ratings to Simkl and importing them back
- expose Simkl ratings option in UI and docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689230b0fcd4832e8e999e2e2370640c