### PR TITLE
Bump app version to 0.4.2

### DIFF
--- a/app.py
+++ b/app.py
@@ -122,7 +122,7 @@ werkzeug_logger.setLevel(logging.WARNING)
 # APPLICATION INFO
 # --------------------------------------------------------------------------- #
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.4.0"
+APP_VERSION = "v0.4.2"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 
 # --------------------------------------------------------------------------- #

--- a/simkl_utils.py
+++ b/simkl_utils.py
@@ -19,7 +19,7 @@ from utils import (
 logger = logging.getLogger(__name__)
 
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.4.0"
+APP_VERSION = "v0.4.2"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 CONFIG_DIR = os.environ.get("PLEXYTRACK_CONFIG_DIR", "/config")
 AUTH_FILE = os.path.join(CONFIG_DIR, "auth.json")

--- a/trakt_utils.py
+++ b/trakt_utils.py
@@ -29,7 +29,7 @@ from utils import (
 logger = logging.getLogger(__name__)
 
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.4.0"
+APP_VERSION = "v0.4.2"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 CONFIG_DIR = os.environ.get("PLEXYTRACK_CONFIG_DIR", "/config")
 AUTH_FILE = os.path.join(CONFIG_DIR, "auth.json")


### PR DESCRIPTION
## Summary
- bump embedded app version string to v0.4.2 for core app and utility modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689efde7d8ac832ebd5a6b06a261d251