### PR TITLE
Fix: support Simkl in the standalone watchlist-only sync (#246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.5.4 (2026-07-21)
+
+### Watchlist sync
+
+- **Simkl watchlist-only sync** (#246): the standalone watchlist-only run (the "sync watchlist" job, `trigger=once, mode=watchlist`) no longer bails out with *"Watchlist sync is only supported with Trakt provider."* when Simkl is the selected tracker. The Plex Discover ↔ Simkl plan-to-watch bidirectional sync (already used inside the full sync) is now reachable from the watchlist-only path as well. In **Both** mode the standalone run drives Trakt and Simkl in the same pass. The full-sync Trakt path is unchanged.
+
 ## v0.5.3 (2026-07-09)
 
 ### Login page

--- a/app.py
+++ b/app.py
@@ -225,7 +225,7 @@ logging.getLogger("werkzeug").setLevel(logging.WARNING)
 # APPLICATION INFO
 # --------------------------------------------------------------------------- #
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.5.3"
+APP_VERSION = "v0.5.4"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 
 # --------------------------------------------------------------------------- #
@@ -1356,65 +1356,124 @@ def sync_watchlists_only(
     plex_history=None,
     trakt_history=None,
 ):
-    """Synchronize Plex and Trakt watchlists without history sync."""
+    """Synchronize watchlists without history sync.
+
+    Supports every configured provider: Trakt (Plex ``<->`` Trakt watchlist),
+    Simkl (Plex Discover ``<->`` Simkl plan-to-watch) and the dual ``both``
+    mode. When the caller supplies an initialized ``plex``/``headers`` pair
+    (the full sync reuses this for its Trakt pass) only the Trakt path runs;
+    Simkl is driven separately inside the full sync. When run standalone (the
+    watchlist-only job) the clients are initialized here for whichever
+    provider(s) the current ``SYNC_PROVIDER`` selects.
+    """
     logger.debug("Starting watchlist-only sync...")
-    
+
     if stop_event.is_set():
         logger.info("Sync cancelled")
         return
 
     plex_history = plex_history or set()
     trakt_history = trakt_history or set()
-    
+
     logger.debug("Plex history size: %d, Trakt history size: %d", len(plex_history), len(trakt_history))
 
-    # Allow standalone execution without pre-initialized clients
-    if plex is None or headers is None:
-        logger.debug("Initializing clients for standalone watchlist sync...")
-        if SYNC_PROVIDER not in ("trakt", "both"):
-            logger.warning("Watchlist sync is only supported with Trakt provider.")
+    def _run_trakt_watchlist(plex_srv, trakt_headers):
+        logger.debug("Calling sync_watchlist (Trakt) function...")
+        try:
+            sync_watchlist(
+                plex_srv,
+                trakt_headers,
+                plex_history,
+                trakt_history,
+                direction=WATCHLISTS_SYNC_DIRECTION,
+            )
+            logger.debug("Trakt watchlist sync completed successfully")
+        except TraktAccountLimitError as exc:
+            logger.error("Watchlist sync skipped: %s", exc)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Watchlist sync failed: %s", exc)
+            import traceback
+            logger.debug("Watchlist sync traceback: %s", traceback.format_exc())
+        else:
+            mirror_trakt_watchlist_to_simkl(trakt_headers)
+
+    def _run_simkl_watchlist(plex_srv, simkl_headers):
+        logger.debug("Calling sync_watchlist_plex_simkl function...")
+        try:
+            sync_watchlist_plex_simkl(
+                plex_srv,
+                simkl_headers,
+                direction=WATCHLISTS_SYNC_DIRECTION,
+            )
+            logger.debug("Simkl watchlist sync completed successfully")
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Simkl watchlist sync failed: %s", exc)
+            import traceback
+            logger.debug("Simkl watchlist sync traceback: %s", traceback.format_exc())
+
+    # Caller supplied initialized Trakt clients (reused inside the full sync):
+    # run only the Trakt path — the full sync drives Simkl separately.
+    if plex is not None and headers is not None:
+        _run_trakt_watchlist(plex, headers)
+        return
+
+    # Standalone watchlist-only run: initialize clients for the configured
+    # provider(s) and sync each one.
+    logger.debug("Initializing clients for standalone watchlist sync...")
+    if SYNC_PROVIDER not in ("trakt", "simkl", "both"):
+        logger.warning("Watchlist sync requires the Trakt or Simkl provider.")
+        return
+
+    load_trakt_tokens()
+    load_simkl_tokens()
+
+    reset_cache()
+    if not test_connections():
+        logger.error("Watchlist sync cancelled due to connection errors.")
+        return
+
+    logger.debug("Getting Plex server...")
+    plex = get_plex_server()
+    if plex is None:
+        logger.error("No Plex server available for watchlist sync")
+        return
+
+    run_trakt = SYNC_PROVIDER in ("trakt", "both")
+    run_simkl = SYNC_PROVIDER in ("simkl", "both")
+
+    if run_trakt:
+        if stop_event.is_set():
+            logger.info("Sync cancelled")
             return
-        reset_cache()
-        if not test_connections():
-            logger.error("Watchlist sync cancelled due to connection errors.")
-            return
-        if plex is None:
-            logger.debug("Getting Plex server...")
-            plex = get_plex_server()
-            if plex is None:
-                logger.error("No Plex server available for watchlist sync")
-                return
-        if headers is None:
-            logger.debug("Setting up Trakt headers...")
-            if not refresh_trakt_token():
-                logger.error("Failed to refresh Trakt token. Aborting watchlist sync.")
-                return
+        logger.debug("Setting up Trakt headers...")
+        if not refresh_trakt_token():
+            logger.error("Failed to refresh Trakt token. Skipping Trakt watchlist sync.")
+        else:
             load_trakt_tokens()
-            headers = {
+            trakt_headers = {
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {os.environ.get('TRAKT_ACCESS_TOKEN')}",
                 "trakt-api-version": "2",
                 "trakt-api-key": os.environ["TRAKT_CLIENT_ID"],
             }
+            _run_trakt_watchlist(plex, trakt_headers)
 
-    logger.debug("Calling sync_watchlist function...")
-    try:
-        sync_watchlist(
-            plex,
-            headers,
-            plex_history,
-            trakt_history,
-            direction=WATCHLISTS_SYNC_DIRECTION,
-        )
-        logger.debug("Watchlist sync completed successfully")
-    except TraktAccountLimitError as exc:
-        logger.error("Watchlist sync skipped: %s", exc)
-    except Exception as exc:  # noqa: BLE001
-        logger.error("Watchlist sync failed: %s", exc)
-        import traceback
-        logger.debug("Watchlist sync traceback: %s", traceback.format_exc())
-    else:
-        mirror_trakt_watchlist_to_simkl(headers)
+    if run_simkl:
+        if stop_event.is_set():
+            logger.info("Sync cancelled")
+            return
+        logger.debug("Setting up Simkl headers...")
+        simkl_token = os.environ.get("SIMKL_ACCESS_TOKEN")
+        simkl_client_id = os.environ.get("SIMKL_CLIENT_ID")
+        if not (simkl_token and simkl_client_id):
+            logger.error("Simkl is not configured. Skipping Simkl watchlist sync.")
+        else:
+            simkl_headers = {
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {simkl_token}",
+                "simkl-api-key": simkl_client_id,
+            }
+            _run_simkl_watchlist(plex, simkl_headers)
 
 
 def mirror_trakt_watchlist_to_simkl(headers) -> None:

--- a/tests/test_watchlist_standalone_simkl.py
+++ b/tests/test_watchlist_standalone_simkl.py
@@ -1,0 +1,118 @@
+"""Tests for the standalone watchlist-only job across providers (issue #246).
+
+The watchlist-only run (``sync_watchlists_job`` -> ``sync_watchlists_only``
+with no pre-initialized clients) used to bail out with
+"Watchlist sync is only supported with Trakt provider." whenever the selected
+provider was Simkl. These tests lock in that the standalone path now routes to
+``sync_watchlist_plex_simkl`` for Simkl and drives both services in ``both``
+mode, while a full-sync caller (plex + Trakt headers supplied) still runs only
+the Trakt path.
+"""
+
+import os
+import sys
+import tempfile
+
+_TMP = tempfile.mkdtemp(prefix="plexytrack_wsimkl_")
+os.environ.setdefault("PLEXYTRACK_CONFIG_DIR", os.path.join(_TMP, "config"))
+os.environ.setdefault("PLEXYTRACK_STATE_DIR", os.path.join(_TMP, "state"))
+os.makedirs(os.environ["PLEXYTRACK_CONFIG_DIR"], exist_ok=True)
+os.makedirs(os.environ["PLEXYTRACK_STATE_DIR"], exist_ok=True)
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import app  # noqa: E402
+
+
+def _patch_common(monkeypatch, plex_obj):
+    """Stub the connection/plumbing helpers so only routing logic is exercised."""
+    monkeypatch.setattr("app.load_trakt_tokens", lambda: True)
+    monkeypatch.setattr("app.load_simkl_tokens", lambda: True)
+    monkeypatch.setattr("app.reset_cache", lambda: None)
+    monkeypatch.setattr("app.test_connections", lambda: True)
+    monkeypatch.setattr("app.get_plex_server", lambda: plex_obj)
+    monkeypatch.setattr("app.refresh_trakt_token", lambda: True)
+    monkeypatch.setattr("app.WATCHLISTS_SYNC_DIRECTION", "both", raising=False)
+
+
+class TestStandaloneSimkl:
+    def test_simkl_only_routes_to_simkl_sync(self, monkeypatch):
+        plex_obj = object()
+        _patch_common(monkeypatch, plex_obj)
+        monkeypatch.setattr("app.SYNC_PROVIDER", "simkl", raising=False)
+        monkeypatch.setenv("SIMKL_ACCESS_TOKEN", "s-token")
+        monkeypatch.setenv("SIMKL_CLIENT_ID", "s-client")
+
+        simkl_calls = []
+        monkeypatch.setattr(
+            "app.sync_watchlist_plex_simkl",
+            lambda plex, headers, *, direction=None: simkl_calls.append((plex, headers, direction)),
+        )
+        trakt_calls = []
+        monkeypatch.setattr("app.sync_watchlist", lambda *a, **k: trakt_calls.append(1))
+
+        app.sync_watchlists_only()
+
+        assert len(simkl_calls) == 1, "Simkl watchlist sync should run for provider=simkl"
+        plex_arg, headers_arg, direction_arg = simkl_calls[0]
+        assert plex_arg is plex_obj
+        assert direction_arg == "both"
+        assert headers_arg["simkl-api-key"] == "s-client"
+        assert headers_arg["Authorization"] == "Bearer s-token"
+        assert trakt_calls == [], "Trakt watchlist sync must not run for provider=simkl"
+
+    def test_simkl_only_without_token_is_skipped(self, monkeypatch):
+        plex_obj = object()
+        _patch_common(monkeypatch, plex_obj)
+        monkeypatch.setattr("app.SYNC_PROVIDER", "simkl", raising=False)
+        monkeypatch.delenv("SIMKL_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("SIMKL_CLIENT_ID", raising=False)
+
+        simkl_calls = []
+        monkeypatch.setattr(
+            "app.sync_watchlist_plex_simkl",
+            lambda *a, **k: simkl_calls.append(1),
+        )
+        app.sync_watchlists_only()
+        assert simkl_calls == [], "Missing Simkl credentials should skip the sync, not crash"
+
+    def test_both_runs_trakt_and_simkl(self, monkeypatch):
+        plex_obj = object()
+        _patch_common(monkeypatch, plex_obj)
+        monkeypatch.setattr("app.SYNC_PROVIDER", "both", raising=False)
+        monkeypatch.setenv("SIMKL_ACCESS_TOKEN", "s-token")
+        monkeypatch.setenv("SIMKL_CLIENT_ID", "s-client")
+        monkeypatch.setenv("TRAKT_ACCESS_TOKEN", "t-token")
+        monkeypatch.setenv("TRAKT_CLIENT_ID", "t-client")
+
+        trakt_calls = []
+        simkl_calls = []
+        monkeypatch.setattr("app.sync_watchlist", lambda *a, **k: trakt_calls.append(1))
+        monkeypatch.setattr("app.mirror_trakt_watchlist_to_simkl", lambda h: None)
+        monkeypatch.setattr(
+            "app.sync_watchlist_plex_simkl",
+            lambda *a, **k: simkl_calls.append(1),
+        )
+
+        app.sync_watchlists_only()
+
+        assert trakt_calls == [1], "Trakt watchlist sync should run in both mode"
+        assert simkl_calls == [1], "Simkl watchlist sync should run in both mode"
+
+
+class TestFullSyncCallerUnchanged:
+    def test_supplied_trakt_clients_run_only_trakt(self, monkeypatch):
+        monkeypatch.setattr("app.SYNC_PROVIDER", "trakt", raising=False)
+        monkeypatch.setattr("app.WATCHLISTS_SYNC_DIRECTION", "both", raising=False)
+        trakt_calls = []
+        simkl_calls = []
+        monkeypatch.setattr("app.sync_watchlist", lambda *a, **k: trakt_calls.append(1))
+        monkeypatch.setattr("app.mirror_trakt_watchlist_to_simkl", lambda h: None)
+        monkeypatch.setattr("app.sync_watchlist_plex_simkl", lambda *a, **k: simkl_calls.append(1))
+        # Ensure the connection plumbing is NOT reached when clients are supplied.
+        monkeypatch.setattr("app.test_connections", lambda: (_ for _ in ()).throw(AssertionError("must not init")))
+
+        app.sync_watchlists_only(object(), {"trakt-api-key": "k"}, set(), set())
+
+        assert trakt_calls == [1]
+        assert simkl_calls == [], "Full-sync Trakt caller must not trigger the Simkl path here"


### PR DESCRIPTION
## Summary

Closes #246.

The standalone **watchlist-only** run (the "sync watchlist" job — `sync_watchlists_job` → `sync_watchlists_only()` with no pre-initialized clients, `trigger=once, mode=watchlist`) bailed out with:

> WARNING — Watchlist sync is only supported with Trakt provider.

whenever Simkl was the selected tracker. This was misleading, because the **full sync** already synchronizes the Plex Discover watchlist with Simkl plan-to-watch through `sync_watchlist_plex_simkl()` (in `simkl_utils.py`). Only the standalone entry point was never wired to it.

## Changes

`sync_watchlists_only()` now routes per provider when run standalone:

- **trakt** — unchanged Plex ↔ Trakt watchlist sync (and the existing mirror to Simkl plan-to-watch).
- **simkl** — builds Simkl headers and calls the existing `sync_watchlist_plex_simkl()` (bidirectional Plex Discover ↔ Simkl plan-to-watch, honoring the configured watchlist direction).
- **both** — runs Trakt and Simkl in the same pass.

The full-sync caller (which supplies an initialized `plex` + Trakt `headers` pair) still runs **only** the Trakt path; Simkl continues to be driven separately inside the full sync, so that behavior is unchanged. `test_connections()` already handles the Simkl-only case, so no change was needed there.

## Tests

Added `tests/test_watchlist_standalone_simkl.py`:

- Simkl-only provider routes to `sync_watchlist_plex_simkl()` with the right headers/direction and does **not** call the Trakt path.
- Missing Simkl credentials skip the sync gracefully (no crash).
- **Both** mode drives Trakt and Simkl.
- The supplied-clients (full-sync) caller still runs Trakt only.

All new tests pass; the rest of the suite is unchanged (pre-existing, unrelated failures in `tests/test_new_features.py` and a collection error in `tests/test_simkl_features.py` are present on `main` before this change too).

## Notes

- No changes to the Simkl API layer — this only wires up an already-implemented and already-tested function.
- Version bumped to `v0.5.4` with a CHANGELOG entry.