### PR TITLE
Fix: validate title-search fallback results before syncing them

### DIFF
--- a/simkl_utils.py
+++ b/simkl_utils.py
@@ -18,6 +18,7 @@ from utils import (
     ids_to_guid,
     match_guids_to_plex,
     sync_items_to_collection,
+    is_confident_title_match,
 )
 
 logger = logging.getLogger(__name__)
@@ -141,8 +142,15 @@ def simkl_request(method: str, endpoint: str, headers: dict, *, retries: int = 2
 
 
 def simkl_search_ids(headers: dict, title: str, *, is_movie: bool = True, year: Optional[int] = None) -> Dict[str, Union[str, int]]:
+    """Search Simkl by title and return ids for the first confident match.
+
+    Only reached when a direct GUID lookup already failed, so title (plus
+    year, for movies) is all we have. Fetch a few candidates and take the
+    first that passes is_confident_title_match(); return {} (caller skips
+    the item) if none do, rather than trusting whatever Simkl ranked first.
+    """
     endpoint = "/search/movies" if is_movie else "/search/shows"
-    params = {"q": title, "limit": 1}
+    params = {"q": title, "limit": 5}
     if year and is_movie:
         params["year"] = year
     try:
@@ -153,13 +161,28 @@ def simkl_search_ids(headers: dict, title: str, *, is_movie: bool = True, year: 
         return {}
     if not isinstance(data, list) or not data:
         return {}
-    ids = data[0].get("ids", {}) or {}
-    for k, v in list(ids.items()):
-        try:
-            ids[k] = int(v) if str(v).isdigit() else v
-        except Exception:
-            pass
-    return ids
+    for candidate in data:
+        if not is_confident_title_match(
+            title,
+            candidate.get("title"),
+            query_year=year,
+            candidate_year=candidate.get("year"),
+        ):
+            continue
+        ids = candidate.get("ids", {}) or {}
+        for k, v in list(ids.items()):
+            try:
+                ids[k] = int(v) if str(v).isdigit() else v
+            except Exception:
+                pass
+        return ids
+    logger.warning(
+        "Simkl search for '%s'%s returned no confident match among %d candidate(s) - skipping",
+        title,
+        f" ({year})" if year else "",
+        len(data),
+    )
+    return {}
 
 
 def add_items_to_simkl_list(

--- a/tests/test_search_fallback_validation.py
+++ b/tests/test_search_fallback_validation.py
@@ -1,0 +1,128 @@
+"""Regression tests for the title-search fallback in simkl_search_ids() and
+trakt_search_ids() (used when a direct Plex GUID lookup fails).
+
+Both used to accept the search API's #1 result with no sanity check. Real
+case: syncing the show "Harlan Coben's Lazarus" (no usable GUID) fell back
+to a Simkl title search whose top hit was an unrelated 2025 movie just
+called "Lazarus", which then got written to watch history. These tests pin
+the fix: reject that case, keep accepting genuine near-matches.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils import is_confident_title_match
+from simkl_utils import simkl_search_ids
+from trakt_utils import trakt_search_ids
+
+
+def _mock_response(json_data):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = json_data
+    return resp
+
+
+class TestIsConfidentTitleMatch:
+    def test_rejects_unrelated_movie_sharing_a_common_word(self):
+        # Real reported case: searching the show "Harlan Coben's Lazarus"
+        # must not accept an unrelated movie just called "Lazarus".
+        assert not is_confident_title_match("Harlan Coben's Lazarus", "Lazarus")
+
+    def test_rejects_completely_different_titles(self):
+        assert not is_confident_title_match("Obsession", "The Man Who Slept")
+
+    def test_accepts_exact_title_match(self):
+        assert is_confident_title_match("Split", "Split", query_year=2017, candidate_year=2017)
+
+    def test_accepts_minor_punctuation_difference(self):
+        assert is_confident_title_match("Alive", "#Alive")
+
+    def test_accepts_subtitle_containment(self):
+        # "The Gentlemen" vs "Gentlemen" - legitimate near-match.
+        assert is_confident_title_match("Gentlemen", "The Gentlemen")
+
+    def test_rejects_same_title_far_apart_in_year(self):
+        # Same normalized title, but 8 years apart - likely a different
+        # production sharing a generic name, not a release-date quirk.
+        assert not is_confident_title_match(
+            "Split", "Split", query_year=2009, candidate_year=2017
+        )
+
+    def test_allows_one_year_release_date_drift(self):
+        assert is_confident_title_match(
+            "Some Movie", "Some Movie", query_year=2016, candidate_year=2017
+        )
+
+    def test_missing_titles_never_match(self):
+        assert not is_confident_title_match(None, "Anything")
+        assert not is_confident_title_match("Anything", None)
+        assert not is_confident_title_match("", "")
+
+    def test_non_latin_titles_compare_instead_of_collapsing(self):
+        # Normalization must not strip CJK/Cyrillic characters, or every
+        # non-Latin title would become an automatic non-match and the
+        # fallback would silently skip those libraries entirely.
+        assert is_confident_title_match("기생충", "기생충")
+        assert not is_confident_title_match("기생충", "올드보이")
+
+    def test_accent_insensitive(self):
+        assert is_confident_title_match("Amelie", "Amélie")
+
+
+class TestSimklSearchIdsValidation:
+    @patch("simkl_utils.simkl_request")
+    def test_skips_unrelated_top_result(self, mock_req):
+        # Simkl's #1 hit for "Harlan Coben's Lazarus" is an unrelated movie.
+        mock_req.return_value = _mock_response(
+            [{"title": "Lazarus", "year": 2025, "ids": {"imdb": "tt31186865"}}]
+        )
+        result = simkl_search_ids({}, "Harlan Coben's Lazarus", is_movie=False)
+        assert result == {}
+
+    @patch("simkl_utils.simkl_request")
+    def test_falls_through_to_a_confident_candidate(self, mock_req):
+        # First candidate is unrelated; second is the real match.
+        mock_req.return_value = _mock_response(
+            [
+                {"title": "Lazarus", "year": 2025, "ids": {"imdb": "tt31186865"}},
+                {"title": "Harlan Coben's Lazarus", "year": 2025, "ids": {"imdb": "tt00000000"}},
+            ]
+        )
+        result = simkl_search_ids({}, "Harlan Coben's Lazarus", is_movie=False)
+        assert result == {"imdb": "tt00000000"}
+
+    @patch("simkl_utils.simkl_request")
+    def test_accepts_confident_movie_match(self, mock_req):
+        mock_req.return_value = _mock_response(
+            [{"title": "Obsession", "year": 2026, "ids": {"imdb": "tt39365308"}}]
+        )
+        result = simkl_search_ids({}, "Obsession", is_movie=True, year=2026)
+        assert result == {"imdb": "tt39365308"}
+
+    @patch("simkl_utils.simkl_request")
+    def test_no_candidates_returns_empty(self, mock_req):
+        mock_req.return_value = _mock_response([])
+        assert simkl_search_ids({}, "Anything", is_movie=True) == {}
+
+
+class TestTraktSearchIdsValidation:
+    @patch("trakt_utils.trakt_request")
+    def test_skips_unrelated_top_result(self, mock_req):
+        mock_req.return_value = _mock_response(
+            [{"movie": {"title": "Lazarus", "year": 2025, "ids": {"imdb": "tt31186865"}}}]
+        )
+        result = trakt_search_ids({}, "Harlan Coben's Lazarus", is_movie=True)
+        assert result == {}
+
+    @patch("trakt_utils.trakt_request")
+    def test_accepts_confident_match(self, mock_req):
+        mock_req.return_value = _mock_response(
+            [{"movie": {"title": "Obsession", "year": 2026, "ids": {"imdb": "tt39365308"}}}]
+        )
+        result = trakt_search_ids({}, "Obsession", is_movie=True, year=2026)
+        assert result == {"imdb": "tt39365308"}
+

--- a/trakt_utils.py
+++ b/trakt_utils.py
@@ -28,6 +28,7 @@ from utils import (
     ids_to_guid,
     match_guids_to_plex,
     sync_items_to_collection,
+    is_confident_title_match,
 )
 
 logger = logging.getLogger(__name__)
@@ -1932,7 +1933,12 @@ def trakt_search_ids(
     is_movie: bool = True,
     year: Optional[int] = None,
 ) -> Dict[str, Union[str, int]]:
-    """Search for a movie/show on Trakt and return its IDs."""
+    """Search for a movie/show on Trakt and return its IDs.
+
+    Only reached when a direct GUID lookup already failed. Each candidate is
+    checked with is_confident_title_match() before being accepted; the first
+    result is not automatically the right one.
+    """
     media_type = "movie" if is_movie else "show"
     query_params = {"query": title, "type": media_type}
     if year:
@@ -1943,10 +1949,24 @@ def trakt_search_ids(
 
     for result in data:
         item = result.get(media_type)
-        if item:
-            ids = item.get("ids", {})
-            if ids:
-                return ids
+        if not item:
+            continue
+        ids = item.get("ids", {})
+        if not ids:
+            continue
+        if not is_confident_title_match(
+            title,
+            item.get("title"),
+            query_year=year,
+            candidate_year=item.get("year"),
+        ):
+            continue
+        return ids
+    logger.warning(
+        "Trakt search for '%s'%s returned no confident match - skipping",
+        title,
+        f" ({year})" if year else "",
+    )
     return {}
 
 

--- a/utils.py
+++ b/utils.py
@@ -1,10 +1,65 @@
+import difflib
 import logging
+import re
+import unicodedata
 from datetime import datetime, timezone
 from numbers import Number
 from typing import Dict, Optional, Tuple, Union
 from plexapi.exceptions import NotFound
 
 logger = logging.getLogger(__name__)
+
+# \W is unicode-aware, so CJK/Cyrillic/etc. titles survive normalization
+# instead of collapsing to an empty string (which would make every
+# non-Latin title an automatic non-match).
+_TITLE_NORMALIZE_RE = re.compile(r"[\W_]+")
+
+
+def _normalize_title(title: Optional[str]) -> str:
+    """Casefold, strip accents, and collapse punctuation/whitespace for loose
+    title comparison ("Amélie" == "Amelie", "WALL·E" == "WALL-E")."""
+    decomposed = unicodedata.normalize("NFKD", title or "")
+    stripped = "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+    return _TITLE_NORMALIZE_RE.sub(" ", stripped.casefold()).strip()
+
+
+def is_confident_title_match(
+    query_title: Optional[str],
+    candidate_title: Optional[str],
+    *,
+    query_year: Optional[int] = None,
+    candidate_year: Optional[int] = None,
+    min_ratio: float = 0.72,
+) -> bool:
+    """Check that a title-search result is plausibly the item we asked for.
+
+    Compares normalized titles and, when both years are known, allows them
+    to differ by one (regional release dates drift). For short or generic
+    titles the #1 search result can be a same-named but unrelated
+    production, so callers should run every candidate through this instead
+    of trusting whatever comes back first.
+
+    Threshold notes: real variants score high ("The Office" / "The Office
+    (US)" = 0.87, "Gentlemen" / "The Gentlemen" = 0.82, "Se7en" / "Seven" =
+    0.80) and wrong items score low ("Batman" / "Batman Begins" = 0.63,
+    "Harlan Coben's Lazarus" / "Lazarus" = 0.48), so 0.72 splits them.
+    "The Batman" / "Batman" (0.75) sneaks past on title alone; the year
+    check catches it.
+    """
+    q = _normalize_title(query_title)
+    c = _normalize_title(candidate_title)
+    if not q or not c:
+        return False
+    ratio = difflib.SequenceMatcher(None, q, c).ratio()
+    if ratio < min_ratio:
+        return False
+    if query_year and candidate_year:
+        try:
+            if abs(int(query_year) - int(candidate_year)) > 1:
+                return False
+        except (TypeError, ValueError):
+            pass
+    return True
 
 
 def to_iso_z(value) -> Optional[str]:


### PR DESCRIPTION
While syncing my library I noticed an unrelated movie showing up in my Simkl history as watched. Tracked it down to the title-search fallback: when a direct Plex GUID lookup fails, `simkl_search_ids()` and `trakt_search_ids()` search the provider by title and accept the #1 result no questions asked. In my case the show "Harlan Coben's Lazarus" had no usable GUID, the fallback searched Simkl for it, and the top hit was a completely unrelated 2025 movie just called "Lazarus" (imdb tt31186865). That went straight into my watch history. Same symptom as #204 but a different cause (that one was a movie/show type mix-up, this one is the fallback blindly trusting position 0).

The fix adds `is_confident_title_match()` in utils.py: it compares normalized titles (case, accents and punctuation ignored, works for non-Latin titles too) and allows the year to be off by one for regional release dates. Both search functions now fetch a few candidates and take the first one that passes the check. If nothing passes they return `{}`, so the item is skipped for that run with a warning in the log. I figured a skipped item you can see in the logs beats a wrong one silently written into your history, but happy to change that if you'd rather it kept guessing.

The 0.72 similarity threshold came from checking real pairs: legit variants like "The Office" / "The Office (US)" (0.87) or "Se7en" / "Seven" (0.80) pass, wrong ones like "Batman" / "Batman Begins" (0.63) or the Lazarus case (0.48) fail. "The Batman" vs "Batman" (0.75) squeaks by on title alone but gets caught by the year check. Notes are in the docstring.

Added tests/test_search_fallback_validation.py, which reproduces the Lazarus case against both functions (mocked API responses) plus the near-matches that must keep working. Full suite: 244 passed; the 14 failures in test_new_features.py and the collection error in test_simkl_features.py are already there on unmodified main.

One thing I left alone: app.py has a second `trakt_search_ids()` (`/search/text`, limit 1) that nothing calls, so I didn't touch it. No CHANGELOG entry either, can add one if you want.
