### PR TITLE
Auto-resume the periodic sync job on container restart

### DIFF
--- a/app.py
+++ b/app.py
@@ -4568,6 +4568,13 @@ def startup_init() -> None:
         logger.warning(
             "No last sync timestamp and history sync disabled; entering SAFE-MODE"
         )
+    # Auto-resume the periodic sync job on boot. Upstream only starts the
+    # scheduler from the manual "Schedule Sync" button (session-scoped), so a
+    # container restart/recreate silently drops the interval job. If a user
+    # was already selected on a previous run, that's a signal sync was
+    # deliberately enabled -- restore it without requiring a UI click.
+    if not SAFE_MODE and load_selected_user():
+        start_scheduler()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
My container restarts kept wiping the sync schedule: the interval job only starts from the Schedule Sync button and lives in memory, so after any restart or recreate (image update, host reboot, compose change) syncing silently stops until I log back into the UI and press the button again. With `restart: unless-stopped` that turned into a recurring chore.

I dug through the history to check whether that was intentional before touching it. Best I can tell it wasn't the goal itself: boot-time `start_scheduler()` went away in 11fd115 ("Fix duplicated logs"), and the duplication there came from Flask's reloader running two processes that each started a scheduler, which that same commit already fixed directly with `use_reloader=False`. Since the app now runs under waitress there's no reloader involved at all, so re-adding the boot-time start doesn't bring the duplicate jobs back. If there was another reason for keeping it manual that I'm missing, happy to hear it.

The change is 7 lines at the end of `startup_init()`: if the app isn't in SAFE-MODE and a sync user was already selected on a previous run, call `start_scheduler()`. That's the same condition the Schedule Sync button checks, so a fresh install with nothing configured behaves exactly as before, and SAFE-MODE still wins. `start_scheduler()` already runs `test_connections()` first, and by that point in `startup_init()` the Plex/Simkl tokens are loaded, so it works without a request context; if the connection test fails the scheduler just doesn't start, same as today.

Been running this on my home server (Plex <-> Simkl, 60-minute interval) since the 6th. After both `docker compose restart` and a full recreate the log shows `Sync job scheduled with interval 60 minutes` with no UI interaction, and the hourly runs carry on. I can also put this behind an env var instead of making it the default if you'd prefer to keep the current behaviour, just let me know.