### PR TITLE
Add Plex collection sync for Simkl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.5.5 (2026-08-09)
+
+### Simkl collection sync
+
+- **Plex collection import for Simkl** (#248): the Collection checkbox is now available when Simkl is selected. PlexyTrack adds movies and shows that are present in the Plex library but not yet tracked by Simkl to **Plan to Watch**.
+- **Status-safe reconciliation**: titles already present anywhere in the Simkl library are skipped, so `watching`, `completed`, `hold`, and `dropped` statuses are never moved back to Plan to Watch.
+- **Honest provider controls**: Simkl collection sync is shown as Plex → Simkl only. Liked Lists remains disabled because Simkl's public API does not yet expose named Custom Lists.
+
+### Documentation
+
+- Clarified the different collection/list capabilities provided by Trakt and Simkl in the README and Unraid template.
+
+### Tests
+
+- Added regression coverage for missing-title imports, status preservation, batching, unresolved Simkl matches, no-op runs, and the enabled Simkl UI control.
+
 ## v0.5.4 (2026-07-21)
 
 ### Watchlist sync

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="static/logo2.png" alt="PlexyTrack Logo" width="200" />
 </p>
 
-This project synchronizes your Plex library with Trakt **and/or** Simkl. Besides watched history it can optionally sync your collection, ratings, watchlists, liked/personal lists, playback progress ("continue watching") and discovery collections. A small Flask web interface lets you choose which features to enable and configure the sync interval. Items that are manually marked as watched in Plex are detected as well. The interface also includes a tool for creating backups of your history, watchlist and ratings.
+This project synchronizes your Plex library with Trakt **and/or** Simkl. Besides watched history it can optionally sync library membership, ratings, watchlists, supported lists, playback progress ("continue watching") and discovery collections. A small Flask web interface lets you choose which features to enable and configure the sync interval. Items that are manually marked as watched in Plex are detected as well. The interface also includes a tool for creating backups of your history, watchlist and ratings.
 The recommended sync interval is **at least 60 minutes**. Shorter intervals generally do not provide any benefit, and you can even synchronize once every 24 hours to reduce the load on your server and the API.
 
 > **First login:** PlexyTrack ships with a default account **`admin` / `admin`**. On your first sign-in you are **forced to change the password** before you can use the app. Do this before exposing PlexyTrack to the internet — see [Exposing PlexyTrack to the internet](#exposing-plexytrack-to-the-internet).
@@ -14,7 +14,9 @@ The recommended sync interval is **at least 60 minutes**. Shorter intervals gene
 - **Bidirectional watched-history sync** between Plex and Trakt or Simkl (incremental, delta-aware).
 - **Dual-provider mode** ("Both"): sync Plex to Trakt **and** Simkl in one pass.
 - **Direct Trakt ↔ Simkl bridge**: ratings, watchlist and movie history propagate between the two services (not only via Plex).
-- **Ratings, collection, liked/personal lists and watchlists** sync, each with a configurable direction (Plex → service, service → Plex, or bidirectional). Ratings work on both Trakt and Simkl.
+- **Collection sync**: mirror Plex library membership with the Trakt collection, or add missing Plex library titles to Simkl Plan to Watch without changing existing Simkl statuses.
+- **Trakt liked/personal lists ↔ Plex collections**: named lists are mirrored in both directions. Simkl Custom Lists are not yet exposed by its public API.
+- **Ratings and watchlists** sync with configurable directions. Both work with Trakt and Simkl.
 - **Plex Discover watchlist as a hub**: kept in sync with Trakt watchlist and Simkl plan-to-watch.
 - **Playback progress ("continue watching")** mirrored between Plex, Trakt and Simkl.
 - **Discovery collections**: Trakt recommendations/trending/popular/anticipated and Simkl trending, materialized as dynamic Plex collections.
@@ -137,8 +139,9 @@ Once configured, PlexyTrack will keep your libraries in sync on the schedule you
 
 ### Collections and watchlists
 
-If you mark a list as liked on Trakt, PlexyTrack will create a Plex collection with the same name and add the matching movies or shows found in your library. Likewise, any collection created in Plex will be mirrored as a list on Trakt. Watchlists are also kept in sync both ways, so adding or removing an item in one platform is reflected in the other.
-When the Simkl provider is selected, your Plex library is copied to the **My TV Shows** and **My Movies** sections on Simkl and Plex collections are mirrored as Simkl lists.
+With Trakt, the **Collection** option mirrors Plex library membership to the Trakt collection and can import the Trakt collection back into Plex. The separate **Liked Lists** option creates Plex collections for liked or personal Trakt lists and mirrors named Plex collections to Trakt lists. Watchlists can also be synchronized in either direction.
+
+With Simkl, **Collection** is a one-way Plex → Simkl library import. Movies and shows that are missing from Simkl are added to **Plan to Watch**; titles already present as watching, completed, on hold, dropped, or already planned are left unchanged. Simkl's public API does not currently allow apps to create or edit named [Custom Lists](https://api.simkl.org/guides/custom-lists), so Plex collection names cannot be recreated on Simkl and **Liked Lists** remains unavailable for this provider.
 
 ### Backup and restore
 
@@ -314,13 +317,15 @@ After selecting a user, you'll see a confirmation message indicating that the us
 
 ## Personalized Sync Direction
 
-Owner users can choose how each sync type flows between Plex and the selected provider. For Watched History, Liked Lists, Watchlists, Collections and Ratings you may select:
+Owner users can choose how each supported sync type flows between Plex and the selected provider. For Watched History, Watchlists, Ratings, and Trakt Collections/Liked Lists you may select:
 
 - **Bidirectional** – changes are mirrored both ways.
 - **Plex → Trakt/Simkl** – only send data from Plex to the service.
 - **Trakt/Simkl → Plex** – only import data from the service into Plex.
 
 Managed users always use the Plex → service direction.
+
+Simkl Collection is always one-way: **Plex → Simkl Plan to Watch**. Simkl Custom Lists cannot be synchronized until Simkl exposes them through its public API.
 
 ## Screenshots
 
@@ -333,4 +338,3 @@ Below are a few images of the PlexyTrack web interface.
   <img src="screenshots/Screenshot%203.png" alt="Screenshot 3" width="400" />
   <img src="screenshots/Screenshot%204.png" alt="Screenshot 4" width="400" />
 </p>
-

--- a/app.py
+++ b/app.py
@@ -119,6 +119,7 @@ from simkl_utils import (
     sync_plex_playback_to_simkl,
     sync_playback_simkl_to_plex,
     sync_watchlist_plex_simkl,
+    sync_plex_collection_to_simkl,
     sync_simkl_trending_to_plex,
 )
 
@@ -225,7 +226,7 @@ logging.getLogger("werkzeug").setLevel(logging.WARNING)
 # APPLICATION INFO
 # --------------------------------------------------------------------------- #
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.5.4"
+APP_VERSION = "v0.5.5"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 
 # --------------------------------------------------------------------------- #
@@ -2242,7 +2243,10 @@ def _sync_inner(provider=None, shared_last_sync=None, defer_save=False):
             logger.info("Sync cancelled")
             return
         try:
-            sync_collection(sync_plex, headers)
+            if active_provider == "trakt":
+                sync_collection(sync_plex, headers)
+            elif active_provider == "simkl":
+                sync_plex_collection_to_simkl(sync_plex, headers)
         except Exception as exc:
             logger.error("Collection sync failed: %s", exc)
 
@@ -2264,7 +2268,9 @@ def _sync_inner(provider=None, shared_last_sync=None, defer_save=False):
                 except Exception as exc:
                     logger.error("Collection import (Trakt -> Plex) failed: %s", exc)
         elif active_provider == "simkl":
-            logger.warning("Collection import from Simkl is not supported.")
+            logger.warning(
+                "Simkl does not expose collection or custom-list imports through its public API."
+            )
 
     if SYNC_LIKED_LISTS and active_provider == "trakt":
         if stop_event.is_set():
@@ -2867,9 +2873,9 @@ def index():
             )
 
         if SYNC_PROVIDER == "simkl":
-            # Watchlist is supported for Simkl; only collection/liked-lists are
-            # Trakt-only.
-            SYNC_COLLECTION = False
+            # Simkl collection sync is one-way because its public API only
+            # exposes the five watchlist statuses, not ownership collections.
+            COLLECTION_SYNC_DIRECTION = DIRECTION_PLEX_TO_SERVICE
             SYNC_LIKED_LISTS = False
 
         # Persist final settings to disk after applying restrictions
@@ -2910,9 +2916,8 @@ def index():
     display_live_sync = LIVE_SYNC
 
     if SYNC_PROVIDER == "simkl":
-        # Collection and liked-lists remain Trakt-only; watchlist is supported
-        # for Simkl (Plex Discover <-> plan-to-watch).
-        display_collection = False
+        # Liked/custom lists remain Trakt-only. Collection adds missing Plex
+        # library titles to Simkl Plan to Watch without changing existing ones.
         display_liked_lists = False
 
     if selected_user and not selected_user.get("is_owner", False):
@@ -2988,9 +2993,7 @@ def sync_once():
         )
 
     if SYNC_PROVIDER == "simkl":
-        # Watchlist is supported for Simkl; only collection/liked-lists are
-        # Trakt-only.
-        SYNC_COLLECTION = False
+        COLLECTION_SYNC_DIRECTION = DIRECTION_PLEX_TO_SERVICE
         SYNC_LIKED_LISTS = False
 
     save_settings()

--- a/simkl_utils.py
+++ b/simkl_utils.py
@@ -24,7 +24,7 @@ from utils import (
 logger = logging.getLogger(__name__)
 
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.5.3"
+APP_VERSION = "v0.5.5"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 CONFIG_DIR = os.environ.get("PLEXYTRACK_CONFIG_DIR", "/config")
 STATE_DIR = os.environ.get("PLEXYTRACK_STATE_DIR", "/state")
@@ -251,6 +251,122 @@ def get_simkl_watchlist(headers: dict, media_type: str = "all") -> dict:
     if isinstance(data, list):
         return {media_type: data}
     return {}
+
+
+def _simkl_collection_identity(media_type: str, item: dict) -> set:
+    """Return stable identity tokens for a Plex or Simkl media item."""
+    tokens = set()
+    ids = item.get("ids", {}) or {}
+    for key, value in ids.items():
+        if value not in (None, ""):
+            normalized_key = "simkl" if key == "simkl_id" else key
+            tokens.add((media_type, "id", normalized_key, str(value)))
+
+    title = " ".join(str(item.get("title") or "").casefold().split())
+    if title:
+        tokens.add(
+            (media_type, "title", title, normalize_year(item.get("year")))
+        )
+    return tokens
+
+
+def _simkl_tracked_collection_identities(data: dict) -> set:
+    """Index every title already tracked by Simkl, regardless of status."""
+    identities = set()
+    for bucket, media_type, object_keys in (
+        ("movies", "movie", ("movie",)),
+        ("shows", "show", ("show",)),
+        ("anime", "show", ("show", "anime")),
+    ):
+        for entry in data.get(bucket, []) or []:
+            media = {}
+            for object_key in object_keys:
+                media = entry.get(object_key, {}) or {}
+                if media:
+                    break
+            if not media and isinstance(entry, dict):
+                media = entry
+            identities.update(_simkl_collection_identity(media_type, media))
+    return identities
+
+
+def _simkl_not_found_count(response: dict) -> int:
+    """Count unresolved titles in an add-to-list response."""
+    not_found = response.get("not_found", {}) if isinstance(response, dict) else {}
+    if not isinstance(not_found, dict):
+        return 0
+    count = 0
+    for value in not_found.values():
+        if isinstance(value, list):
+            count += len(value)
+        elif isinstance(value, int):
+            count += value
+    return count
+
+
+def sync_plex_collection_to_simkl(
+    plex, headers: dict, *, batch_size: int = 500
+) -> int:
+    """Add missing Plex library titles to Simkl's Plan to Watch list.
+
+    Simkl's public API does not expose named Custom Lists or an ownership-style
+    collection. Its supported equivalent for an unwatched library import is
+    ``plantowatch``. Existing Simkl titles are skipped regardless of their
+    current status so this sync never moves completed, watching, held, or
+    dropped items back to Plan to Watch.
+
+    Returns the number of titles accepted by Simkl.
+    """
+    tracked_identities = _simkl_tracked_collection_identities(
+        get_simkl_watchlist(headers)
+    )
+    queued_identities = set(tracked_identities)
+    queued = []
+
+    for section in plex.library.sections():
+        if section.type not in ("movie", "show"):
+            continue
+        for item in section.all():
+            media_type = "movie" if section.type == "movie" else "show"
+            payload_item: Dict[str, Union[str, int, dict]] = {
+                "title": getattr(item, "title", "")
+            }
+            year = normalize_year(getattr(item, "year", None))
+            if year is not None:
+                payload_item["year"] = year
+            guid = best_guid(item)
+            ids = guid_to_ids(guid) if guid else {}
+            if ids:
+                payload_item["ids"] = ids
+
+            identities = _simkl_collection_identity(media_type, payload_item)
+            if identities & queued_identities:
+                continue
+            queued.append((media_type, payload_item))
+            queued_identities.update(identities)
+
+    accepted = 0
+    for start in range(0, len(queued), batch_size):
+        batch = queued[start:start + batch_size]
+        movies = [item for media_type, item in batch if media_type == "movie"]
+        shows = [item for media_type, item in batch if media_type == "show"]
+        response = add_items_to_simkl_list(
+            headers,
+            movies=movies or None,
+            shows=shows or None,
+            target_list="plantowatch",
+        )
+        accepted += max(0, len(batch) - _simkl_not_found_count(response))
+
+    if queued:
+        logger.info(
+            "Plex collection -> Simkl Plan to Watch: added %d of %d missing title(s)",
+            accepted,
+            len(queued),
+        )
+    else:
+        logger.info("Plex collection -> Simkl: no missing titles")
+    return accepted
 
 
 def sync_plex_watchlist_to_simkl(plex, headers: dict, target_list: str = "plantowatch") -> int:

--- a/templates/index.html
+++ b/templates/index.html
@@ -134,12 +134,16 @@
             <fieldset class="sync-options">
               <legend>Sync Options</legend>
               <div class="checkbox-group">
-                <input type="checkbox" id="collection" name="collection" {% if collection %}checked{% endif %} {% if provider == 'simkl' %}disabled{% endif %}>
+                <input type="checkbox" id="collection" name="collection" {% if collection %}checked{% endif %}>
                 <label for="collection">Collection</label>
                 <select id="collection_direction" name="collection_direction" class="direction-select">
+                  {% if provider == 'simkl' %}
+                  <option value="plex_to_service" selected>Plex → Simkl Plan to Watch</option>
+                  {% else %}
                   <option value="both" {% if collection_direction == 'both' %}selected{% endif %}>Bidirectional</option>
                   <option value="plex_to_service" {% if collection_direction == 'plex_to_service' %}selected{% endif %}>Plex → {{ provider.capitalize() }}</option>
                   <option value="service_to_plex" {% if collection_direction == 'service_to_plex' %}selected{% endif %}>{{ provider.capitalize() }} → Plex</option>
+                  {% endif %}
                 </select>
               </div>
               <div class="checkbox-group">
@@ -161,7 +165,7 @@
                 </select>
               </div>
               <div class="checkbox-group">
-                <input type="checkbox" id="liked_lists" name="liked_lists" {% if liked_lists %}checked{% endif %} {% if provider == 'simkl' %}disabled{% endif %}>
+                <input type="checkbox" id="liked_lists" name="liked_lists" {% if liked_lists %}checked{% endif %} {% if provider == 'simkl' %}disabled data-provider-disabled{% endif %}>
                 <label for="liked_lists">Liked Lists</label>
                 <select id="lists_direction" name="lists_direction" class="direction-select">
                   <option value="both" {% if lists_direction == 'both' %}selected{% endif %}>Bidirectional</option>

--- a/tests/test_simkl_collection_sync.py
+++ b/tests/test_simkl_collection_sync.py
@@ -1,0 +1,180 @@
+"""Regression coverage for Plex collection sync with Simkl (#248)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import simkl_utils
+
+
+def _plex_item(title, year, media_type, guid=None):
+    guids = [SimpleNamespace(id=guid)] if guid else []
+    return SimpleNamespace(
+        title=title,
+        year=year,
+        type=media_type,
+        guid=guid,
+        guids=guids,
+    )
+
+
+def _section(media_type, items):
+    section = MagicMock()
+    section.type = media_type
+    section.all.return_value = items
+    return section
+
+
+def test_collection_adds_only_titles_missing_from_every_simkl_status(monkeypatch):
+    plex = MagicMock()
+    plex.library.sections.return_value = [
+        _section(
+            "movie",
+            [
+                _plex_item("Already Completed", 2020, "movie", "imdb://tt100"),
+                _plex_item("New Movie", 2024, "movie", "tmdb://200"),
+            ],
+        ),
+        _section(
+            "show",
+            [
+                _plex_item("Dropped Show", 2019, "show", "tvdb://300"),
+                _plex_item("New Show", 2025, "show"),
+            ],
+        ),
+    ]
+    monkeypatch.setattr(
+        simkl_utils,
+        "get_simkl_watchlist",
+        lambda headers: {
+            "movies": [
+                {
+                    "status": "completed",
+                    "movie": {
+                        "title": "Already Completed",
+                        "year": 2020,
+                        "ids": {"imdb": "tt100"},
+                    },
+                }
+            ],
+            "shows": [
+                {
+                    "status": "dropped",
+                    "show": {
+                        "title": "Dropped Show",
+                        "year": 2019,
+                        "ids": {"tvdb": 300},
+                    },
+                }
+            ],
+        },
+    )
+    captured = {}
+
+    def fake_add(headers, *, movies=None, shows=None, target_list=None):
+        captured.update(movies=movies, shows=shows, target_list=target_list)
+        return {"added": {"movies": movies or [], "shows": shows or []}}
+
+    monkeypatch.setattr(simkl_utils, "add_items_to_simkl_list", fake_add)
+
+    added = simkl_utils.sync_plex_collection_to_simkl(plex, {"auth": "ok"})
+
+    assert added == 2
+    assert captured["target_list"] == "plantowatch"
+    assert [item["title"] for item in captured["movies"]] == ["New Movie"]
+    assert captured["movies"][0]["ids"] == {"tmdb": 200}
+    assert [item["title"] for item in captured["shows"]] == ["New Show"]
+
+
+def test_collection_batches_writes_and_counts_not_found(monkeypatch):
+    plex = MagicMock()
+    plex.library.sections.return_value = [
+        _section(
+            "movie",
+            [
+                _plex_item("One", 2021, "movie", "tmdb://1"),
+                _plex_item("Two", 2022, "movie", "tmdb://2"),
+                _plex_item("Three", 2023, "movie", "tmdb://3"),
+            ],
+        )
+    ]
+    monkeypatch.setattr(simkl_utils, "get_simkl_watchlist", lambda headers: {})
+    responses = [
+        {"not_found": {"movies": [{"title": "Two"}]}},
+        {"added": {"movies": [{"title": "Three"}]}},
+    ]
+    batches = []
+
+    def fake_add(headers, *, movies=None, shows=None, target_list=None):
+        batches.append(movies)
+        return responses.pop(0)
+
+    monkeypatch.setattr(simkl_utils, "add_items_to_simkl_list", fake_add)
+
+    added = simkl_utils.sync_plex_collection_to_simkl(
+        plex, {}, batch_size=2
+    )
+
+    assert added == 2
+    assert [[item["title"] for item in batch] for batch in batches] == [
+        ["One", "Two"],
+        ["Three"],
+    ]
+
+
+def test_collection_is_a_noop_when_every_title_is_already_tracked(monkeypatch):
+    plex = MagicMock()
+    plex.library.sections.return_value = [
+        _section(
+            "movie",
+            [_plex_item("Existing", 2020, "movie", "imdb://tt999")],
+        )
+    ]
+    monkeypatch.setattr(
+        simkl_utils,
+        "get_simkl_watchlist",
+        lambda headers: {
+            "movies": [
+                {
+                    "status": "hold",
+                    "movie": {
+                        "title": "Existing",
+                        "year": 2020,
+                        "ids": {"imdb": "tt999"},
+                    },
+                }
+            ]
+        },
+    )
+    add = MagicMock()
+    monkeypatch.setattr(simkl_utils, "add_items_to_simkl_list", add)
+
+    assert simkl_utils.sync_plex_collection_to_simkl(plex, {}) == 0
+    add.assert_not_called()
+
+
+def test_simkl_collection_control_is_enabled_and_one_way(monkeypatch):
+    import app as app_module
+
+    monkeypatch.setattr(app_module, "load_trakt_tokens", lambda: False)
+    monkeypatch.setattr(app_module, "load_simkl_tokens", lambda: True)
+    monkeypatch.setattr(app_module, "load_provider", lambda: None)
+    monkeypatch.setattr(app_module, "load_settings", lambda: None)
+    monkeypatch.setattr(
+        app_module,
+        "load_selected_user",
+        lambda: {"username": "owner", "role": "owner", "is_owner": True},
+    )
+    monkeypatch.setattr(app_module, "SYNC_PROVIDER", "simkl")
+    monkeypatch.setattr(app_module, "SYNC_COLLECTION", True)
+
+    client = app_module.app.test_client()
+    with client.session_transaction() as session:
+        session["authenticated"] = True
+
+    response = client.get("/")
+    html = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'id="collection" name="collection" checked' in html
+    assert "Plex → Simkl Plan to Watch" in html
+    assert 'id="collection" name="collection" checked disabled' not in html

--- a/trakt_utils.py
+++ b/trakt_utils.py
@@ -34,7 +34,7 @@ from utils import (
 logger = logging.getLogger(__name__)
 
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.5.3"
+APP_VERSION = "v0.5.5"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 CONFIG_DIR = os.environ.get("PLEXYTRACK_CONFIG_DIR", "/config")
 STATE_DIR = os.environ.get("PLEXYTRACK_STATE_DIR", "/state")

--- a/unraid-template/plexytrack.xml
+++ b/unraid-template/plexytrack.xml
@@ -14,7 +14,7 @@
   <Project>https://github.com/Drakonis96/plexytrack</Project>
   <ReadMe>https://github.com/Drakonis96/plexytrack/blob/main/README.md</ReadMe>
   <TemplateURL>https://raw.githubusercontent.com/Drakonis96/plexytrack-unraid-template/main/plexytrack.xml</TemplateURL>
-  <Overview>PlexyTrack synchronizes your Plex library with Trakt and/or Simkl. It supports bidirectional sync of watched history, ratings, collections, liked lists and watchlists. A simple web UI lets you configure sync options, select Plex users, and create backups of your data. Live Sync via Plex webhooks is also available for instant updates. After installing the container, open the WebUI to authenticate Plex and then connect Trakt and/or Simkl.</Overview>
+  <Overview>PlexyTrack synchronizes your Plex library with Trakt and/or Simkl. Watched history, ratings, and watchlists support both providers. Trakt collections and named lists can sync in both directions; with Simkl, missing Plex library titles can be added one-way to Plan to Watch while existing Simkl statuses are preserved. Simkl Custom Lists are not available through its public API. A simple web UI lets you configure sync options, select Plex users, and create backups of your data. Live Sync via Plex webhooks is also available for instant updates. After installing the container, open the WebUI to authenticate Plex and then connect Trakt and/or Simkl.</Overview>
   <Category>MediaApp:Other</Category>
   <WebUI>http://[IP]:[PORT:5030]</WebUI>
   <Icon>https://raw.githubusercontent.com/Drakonis96/plexytrack/main/static/logo2.png</Icon>


### PR DESCRIPTION
## Summary

- enable the Collection option when Simkl is selected
- add Plex movies and shows missing from Simkl to Plan to Watch
- preserve every existing Simkl status instead of moving tracked titles
- force the Simkl collection direction to Plex → Simkl
- clarify that named Simkl Custom Lists are not available through the public API
- bump the application version and changelog to v0.5.5

## Root cause

The UI intentionally disabled Collection for Simkl and the sync pipeline always routed collection writes through the Trakt implementation. The README and Unraid overview nevertheless promised Simkl collection/list support.

Simkl's public API currently exposes only its five watchlist statuses, not named Custom Lists. This implementation uses the supported Plan to Watch import path and documents that limitation explicitly.

## Validation

- 29 targeted Simkl collection/orchestration tests passed
- 217 repository tests passed with the two pre-existing stale suites excluded
- Python bytecode compilation passed
- Unraid XML validation passed
- staged diff whitespace validation passed

The excluded legacy suites already fail on `main`: `tests/test_simkl_features.py` imports missing APIs, and `tests/test_new_features.py` expects unrelated features that are not implemented.

Closes #248