### PR TITLE
Fix large Plex watched-history import performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.5.6 (2026-08-22)
+
+### Plex watched-history performance
+
+- **Bulk episode resolution** (#253): service-to-Plex imports now fetch and index each TV library's episodes once instead of repeating section, show, and episode lookups for every watched episode.
+- **Fast fallback matching**: episodes are indexed by external GUID and by normalized show/season/episode position. If a bulk query is unavailable, PlexyTrack caches one episode listing per show instead of querying the show for every item.
+- **Correct watched-state checks**: PlexAPI's `isWatched` property is no longer called as a function, eliminating unnecessary title searches for movies that were already found by GUID.
+- **Visible progress**: large Plex watched-state updates now log progress every 100 processed items instead of appearing stuck after the GUID-index message.
+
+### Tests
+
+- Added regression coverage for bulk episode indexing, tuple-based Simkl episode keys, the cached compatibility fallback, and PlexAPI watched-state properties.
+- Verified the fix with both the minimum supported PlexAPI 4.15.0 and the current PlexAPI 4.18.2.
+
 ## v0.5.5 (2026-08-09)
 
 ### Simkl collection sync

--- a/app.py
+++ b/app.py
@@ -226,7 +226,7 @@ logging.getLogger("werkzeug").setLevel(logging.WARNING)
 # APPLICATION INFO
 # --------------------------------------------------------------------------- #
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.5.5"
+APP_VERSION = "v0.5.6"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 
 # --------------------------------------------------------------------------- #

--- a/plex_utils.py
+++ b/plex_utils.py
@@ -955,20 +955,108 @@ def get_server_based_history(plex, mindate: Optional[str] = None) -> Tuple[
     return movies, episodes
 
 
+def _is_watched(item) -> bool:
+    """Return Plex watched state across PlexAPI property/method variants."""
+    watched = getattr(item, "isWatched", None)
+    if callable(watched):
+        watched = watched()
+    if watched is not None:
+        return bool(watched)
+    return bool(getattr(item, "viewCount", 0))
+
+
+def _episode_position_key(show_title, season, episode) -> Optional[Tuple[str, int, int]]:
+    """Return a normalized show/season/episode lookup key when values are valid."""
+    if not show_title or season is None or episode is None:
+        return None
+    try:
+        season_number = int(season)
+        episode_number = int(episode)
+    except (TypeError, ValueError):
+        return None
+    normalized_title = " ".join(str(show_title).casefold().split())
+    return normalized_title, season_number, episode_number
+
+
 def update_plex(
     plex,
     movies: Set[Tuple[str, Optional[int], Optional[str]]],
-    episodes: Set[Tuple[str, str, Optional[str]]],  # Only allow str for key, not Tuple fallback
+    episodes: Set[Tuple[str, str, object]],
 ) -> None:
     """Mark items as watched in Plex when missing."""
     movie_count = 0
     episode_count = 0
+    total_items = len(movies) + len(episodes)
 
-    for title, year, guid in movies:
+    # A TV-section query can return every episode, including its external
+    # GUIDs, in one paginated operation.  Build both lookup shapes once so a
+    # large Simkl import does not execute section/show/allLeaves requests for
+    # every episode individually.
+    episode_guid_lookup: Dict[str, object] = {}
+    episode_position_lookup: Dict[Tuple[str, int, int], object] = {}
+    if episodes:
+        for section in plex.library.sections():
+            if section.type != "show":
+                continue
+            try:
+                library_episodes = section.all(libtype="episode")
+            except Exception as exc:
+                logger.warning(
+                    "Failed to build episode lookup for Plex section %s: %s",
+                    getattr(section, "title", "unknown"),
+                    exc,
+                )
+                continue
+
+            for episode in library_episodes:
+                primary_guid = getattr(episode, "guid", None)
+                if primary_guid:
+                    episode_guid_lookup[primary_guid] = episode
+                for episode_guid in getattr(episode, "guids", []) or []:
+                    guid_id = getattr(episode_guid, "id", None)
+                    if guid_id:
+                        episode_guid_lookup[guid_id] = episode
+
+                position_key = _episode_position_key(
+                    getattr(episode, "grandparentTitle", None),
+                    getattr(
+                        episode,
+                        "parentIndex",
+                        getattr(episode, "seasonNumber", None),
+                    ),
+                    getattr(episode, "index", getattr(episode, "episodeNumber", None)),
+                )
+                if position_key:
+                    episode_position_lookup[position_key] = episode
+
+        logger.info(
+            "Built Plex episode lookup with %d GUID entries and %d episode positions",
+            len(episode_guid_lookup),
+            len(episode_position_lookup),
+        )
+
+    # Only used if the bulk episode query was unavailable or an item lacked
+    # usable metadata.  Cache all leaves per show so even the compatibility
+    # fallback performs at most one remote lookup per show.
+    fallback_episode_lookup: Dict[str, Dict[Tuple[int, int], object]] = {}
+
+    def log_progress(processed: int) -> None:
+        if total_items >= 100 and processed and (
+            processed % 100 == 0 or processed == total_items
+        ):
+            logger.info(
+                "Plex watched-state update progress: %d/%d items processed (%d marked)",
+                processed,
+                total_items,
+                movie_count + episode_count,
+            )
+
+    for movie_index, (title, year, guid) in enumerate(movies, start=1):
+        log_progress(movie_index - 1)
         if guid and valid_guid(guid):
             try:
                 item = find_item_by_guid(plex, guid)
-                if item and getattr(item, "isWatched", lambda: bool(getattr(item, "viewCount", 0)))():
+                if item and _is_watched(item):
                     continue
                 if item:
                     item.markWatched()
@@ -997,58 +1085,86 @@ def update_plex(
             continue
 
         try:
-            # Check if already watched using isWatched property or viewCount
-            is_watched = getattr(found, "isWatched", False) or bool(getattr(found, "viewCount", 0))
-            if is_watched:
+            if _is_watched(found):
                 continue
             found.markWatched()
             movie_count += 1
         except Exception as exc:
             logger.debug("Failed to mark movie '%s' as watched: %s", found.title, exc)
 
-    for show_title, code, key in episodes:
+    for episode_index, (show_title, code, key) in enumerate(episodes, start=1):
+        log_progress(len(movies) + episode_index - 1)
         guid: Optional[str] = None
         if isinstance(key, str):
             guid = key if valid_guid(key) else None
-        # Remove tuple fallback for Trakt, only allow for Simkl (not present here)
-
-        if guid:
-            try:
-                item = find_item_by_guid(plex, guid)
-                if item:
-                    # Check if already watched using isWatched property or viewCount
-                    is_watched = getattr(item, "isWatched", False) or bool(getattr(item, "viewCount", 0))
-                    if is_watched:
-                        continue
-                    item.markWatched()
-                    episode_count += 1
-                    continue
-            except Exception as exc:
-                logger.debug("GUID search failed for %s: %s", guid, exc)
 
         try:
             season_num, episode_num = map(int, code.upper().lstrip("S").split("E"))
-        except ValueError:
+        except (AttributeError, TypeError, ValueError):
             logger.debug("Invalid episode code format: %s", code)
             continue
 
-        show_obj = get_show_from_library(plex, show_title)
-        if not show_obj:
-            logger.debug("Show not found in Plex library: %s", show_title)
-            continue
+        item = episode_guid_lookup.get(guid) if guid else None
+        if item is None:
+            position_key = _episode_position_key(show_title, season_num, episode_num)
+            if position_key:
+                item = episode_position_lookup.get(position_key)
 
+        if item is not None:
+            try:
+                if _is_watched(item):
+                    continue
+                item.markWatched()
+                episode_count += 1
+                continue
+            except Exception as exc:
+                logger.debug("Failed marking episode %s - %s as watched: %s", show_title, code, exc)
+                continue
+
+        normalized_show_title = " ".join((show_title or "").casefold().split())
+        if not normalized_show_title:
+            logger.debug("Episode has no show title and cannot be matched: %s", code)
+            continue
+        if normalized_show_title not in fallback_episode_lookup:
+            show_episodes: Dict[Tuple[int, int], object] = {}
+            show_obj = get_show_from_library(plex, show_title)
+            if show_obj:
+                try:
+                    for show_episode in show_obj.episodes():
+                        show_episode_key = _episode_position_key(
+                            show_title,
+                            getattr(
+                                show_episode,
+                                "parentIndex",
+                                getattr(show_episode, "seasonNumber", None),
+                            ),
+                            getattr(
+                                show_episode,
+                                "index",
+                                getattr(show_episode, "episodeNumber", None),
+                            ),
+                        )
+                        if show_episode_key:
+                            show_episodes[(show_episode_key[1], show_episode_key[2])] = show_episode
+                except Exception as exc:
+                    logger.debug("Failed loading episodes for show %s: %s", show_title, exc)
+            fallback_episode_lookup[normalized_show_title] = show_episodes
+
+        ep_obj = fallback_episode_lookup[normalized_show_title].get(
+            (season_num, episode_num)
+        )
+        if ep_obj is None:
+            logger.debug("Episode not found in Plex library: %s - %s", show_title, code)
+            continue
         try:
-            # Try to find the episode using the show's episode method
-            ep_obj = show_obj.episode(season=season_num, episode=episode_num)
-            # Check if already watched using isWatched property or viewCount
-            is_watched = getattr(ep_obj, "isWatched", False) or bool(getattr(ep_obj, "viewCount", 0))
-            if is_watched:
+            if _is_watched(ep_obj):
                 continue
             ep_obj.markWatched()
             episode_count += 1
         except Exception as exc:
             logger.debug("Failed marking episode %s - %s as watched: %s", show_title, code, exc)
 
+    log_progress(total_items)
     if movie_count or episode_count:
         logger.info("Marked %d movies and %d episodes as watched in Plex", movie_count, episode_count)
     else:

--- a/simkl_utils.py
+++ b/simkl_utils.py
@@ -24,7 +24,7 @@ from utils import (
 logger = logging.getLogger(__name__)
 
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.5.5"
+APP_VERSION = "v0.5.6"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 CONFIG_DIR = os.environ.get("PLEXYTRACK_CONFIG_DIR", "/config")
 STATE_DIR = os.environ.get("PLEXYTRACK_STATE_DIR", "/state")

--- a/tests/test_update_plex_performance.py
+++ b/tests/test_update_plex_performance.py
@@ -1,0 +1,187 @@
+"""Regression tests for large service-to-Plex watched-history imports."""
+
+from types import SimpleNamespace
+
+import plex_utils
+import utils
+
+
+class DummyEpisode:
+    def __init__(self, number, counters):
+        self.guid = f"plex://episode/{number}"
+        self.guids = [SimpleNamespace(id=f"tvdb://{1000 + number}")]
+        self.grandparentTitle = "Example Show"
+        self.parentIndex = 1
+        self.index = number
+        self.isWatched = False
+        self.viewCount = 0
+        self._counters = counters
+
+    def markWatched(self):
+        self._counters["mark_watched"] += 1
+
+
+class DummyShowSection:
+    type = "show"
+    title = "TV Shows"
+
+    def __init__(self, episodes, counters):
+        self._episodes = episodes
+        self._counters = counters
+
+    def all(self, libtype=None):
+        assert libtype == "episode"
+        self._counters["bulk_episode_queries"] += 1
+        return self._episodes
+
+    def get(self, title):
+        self._counters["show_queries"] += 1
+        raise AssertionError("bulk-indexed episodes must not trigger per-show queries")
+
+
+class DummyLibrary:
+    def __init__(self, section, counters):
+        self._section = section
+        self._counters = counters
+
+    def sections(self):
+        self._counters["section_queries"] += 1
+        return [self._section]
+
+
+def test_update_plex_bulk_indexes_episodes_once():
+    counters = {
+        "section_queries": 0,
+        "bulk_episode_queries": 0,
+        "show_queries": 0,
+        "mark_watched": 0,
+    }
+    library_episodes = [DummyEpisode(number, counters) for number in range(1, 101)]
+    section = DummyShowSection(library_episodes, counters)
+    plex = SimpleNamespace(library=DummyLibrary(section, counters))
+    service_episodes = {
+        (
+            "Example Show",
+            f"S01E{number:02d}",
+            f"tvdb://{1000 + number}"
+            if number % 2
+            else ("tvdb://1", f"S01E{number:02d}"),
+        )
+        for number in range(1, 101)
+    }
+
+    plex_utils.update_plex(plex, set(), service_episodes)
+
+    assert counters == {
+        "section_queries": 1,
+        "bulk_episode_queries": 1,
+        "show_queries": 0,
+        "mark_watched": 100,
+    }
+
+
+class DummyFallbackShow:
+    title = "Example Show"
+
+    def __init__(self, episodes, counters):
+        self._episodes = episodes
+        self._counters = counters
+
+    def episodes(self):
+        self._counters["show_episode_queries"] += 1
+        return self._episodes
+
+
+class DummyFallbackSection(DummyShowSection):
+    def __init__(self, episodes, counters):
+        super().__init__(episodes, counters)
+        self._show = DummyFallbackShow(episodes, counters)
+
+    def all(self, libtype=None):
+        self._counters["bulk_episode_queries"] += 1
+        raise RuntimeError("bulk episode lookup unavailable")
+
+    def get(self, title):
+        self._counters["show_queries"] += 1
+        return self._show
+
+
+def test_update_plex_fallback_queries_each_show_once():
+    counters = {
+        "section_queries": 0,
+        "bulk_episode_queries": 0,
+        "show_queries": 0,
+        "show_episode_queries": 0,
+        "mark_watched": 0,
+    }
+    library_episodes = [DummyEpisode(number, counters) for number in range(1, 101)]
+    section = DummyFallbackSection(library_episodes, counters)
+    plex = SimpleNamespace(library=DummyLibrary(section, counters))
+    service_episodes = {
+        ("Example Show", f"S01E{number:02d}", ("tvdb://1", f"S01E{number:02d}"))
+        for number in range(1, 101)
+    }
+
+    plex_utils.update_plex(plex, set(), service_episodes)
+
+    assert counters == {
+        "section_queries": 2,
+        "bulk_episode_queries": 1,
+        "show_queries": 1,
+        "show_episode_queries": 1,
+        "mark_watched": 100,
+    }
+
+
+class DummyMovie:
+    title = "Already Watched"
+    year = 2026
+    guid = "plex://movie/1"
+    guids = [SimpleNamespace(id="imdb://tt123")]
+    isWatched = True
+    viewCount = 1
+
+    def markWatched(self):
+        raise AssertionError("an already-watched movie must not be marked again")
+
+
+class DummyMovieSection:
+    type = "movie"
+    title = "Movies"
+
+    def __init__(self, counters):
+        self._counters = counters
+
+    def all(self):
+        self._counters["bulk_movie_queries"] += 1
+        return [DummyMovie()]
+
+    def search(self, **kwargs):
+        self._counters["title_queries"] += 1
+        return []
+
+
+def test_update_plex_treats_is_watched_as_a_property():
+    counters = {
+        "section_queries": 0,
+        "bulk_movie_queries": 0,
+        "title_queries": 0,
+    }
+    section = DummyMovieSection(counters)
+    plex = SimpleNamespace(
+        machineIdentifier="issue-253-movie-test",
+        library=DummyLibrary(section, counters),
+    )
+    utils.reset_sections_cache()
+
+    plex_utils.update_plex(
+        plex,
+        {("Already Watched", 2026, "imdb://tt123")},
+        set(),
+    )
+
+    assert counters == {
+        "section_queries": 1,
+        "bulk_movie_queries": 1,
+        "title_queries": 0,
+    }

--- a/trakt_utils.py
+++ b/trakt_utils.py
@@ -34,7 +34,7 @@ from utils import (
 logger = logging.getLogger(__name__)
 
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.5.5"
+APP_VERSION = "v0.5.6"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 CONFIG_DIR = os.environ.get("PLEXYTRACK_CONFIG_DIR", "/config")
 STATE_DIR = os.environ.get("PLEXYTRACK_STATE_DIR", "/state")


### PR DESCRIPTION
## Summary

- Resolve Plex episodes in one bulk TV-library pass instead of repeating library and show queries for every item.
- Cache fallback episode lists per show when bulk episode enumeration is unavailable.
- Handle the PlexAPI `isWatched` property correctly for movies.
- Add progress logging for large watched-history imports.
- Bump the application version and changelog to v0.5.6.

## Root cause

The generic GUID index only included movies and shows. Every episode in a large import therefore fell through to repeated section, show, and episode lookups. The movie path also invoked the PlexAPI `isWatched` boolean property as a callable, which triggered unnecessary title-search fallbacks.

## Validation

- A 100-episode reproduction went from 101 section scans, 100 show lookups, and 100 episode lookups to one section scan and one bulk episode query.
- An issue-sized 3,283-episode simulation used one section scan, one bulk episode query, and zero show lookups.
- Five focused regression tests pass with both PlexAPI 4.15.0 and 4.18.2.
- 220 applicable repository tests pass; two unrelated stale suites remain excluded because they reference features that are absent from the current main branch.
- Python compilation, whitespace validation, a local Docker arm64 build, and a container version smoke test pass.

Closes #253