### PR TITLE
Fix strict Simkl history matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.5.7 (2026-08-25)
+
+### Strict Simkl matching
+
+- **External-ID-only history import** (#255): Simkl movies and episodes are now applied to Plex only when their IMDb, TMDB, TVDB, or AniDB identifiers resolve to the expected media type. Unmatched items are skipped and logged instead of falling back to a potentially ambiguous title.
+- **Exact episode parent resolution**: tuple-based Simkl episode keys now resolve the Plex show by GUID first, then select the episode by season and number. This prevents identically named series, such as the anime and live-action versions of *One Piece*, from sharing watched state.
+- **Performance preserved**: strict episode matching extends the bulk index introduced in v0.5.6 with Plex parent rating keys, retaining one bulk episode load per TV library and one cached fallback load per exact show.
+
+### Tests
+
+- Added regression coverage for duplicate show titles, unknown show and movie GUIDs, bulk exact-parent matching, and the cached strict fallback path.
+
 ## v0.5.6 (2026-08-22)
 
 ### Plex watched-history performance

--- a/app.py
+++ b/app.py
@@ -226,7 +226,7 @@ logging.getLogger("werkzeug").setLevel(logging.WARNING)
 # APPLICATION INFO
 # --------------------------------------------------------------------------- #
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.5.6"
+APP_VERSION = "v0.5.7"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 
 # --------------------------------------------------------------------------- #

--- a/plex_utils.py
+++ b/plex_utils.py
@@ -983,17 +983,23 @@ def update_plex(
     movies: Set[Tuple[str, Optional[int], Optional[str]]],
     episodes: Set[Tuple[str, str, object]],
 ) -> None:
-    """Mark items as watched in Plex when missing."""
+    """Mark Simkl items watched only when their external IDs match Plex.
+
+    A Simkl episode key is either an episode GUID or ``(show_guid, code)``.
+    Resolve tuple keys through the exact Plex show before applying the season
+    and episode coordinates.  Never fall back to a title match: unrelated
+    shows can share a title, as the anime and live-action ``One Piece`` do.
+    """
     movie_count = 0
     episode_count = 0
     total_items = len(movies) + len(episodes)
 
     # A TV-section query can return every episode, including its external
-    # GUIDs, in one paginated operation.  Build both lookup shapes once so a
-    # large Simkl import does not execute section/show/allLeaves requests for
-    # every episode individually.
+    # GUIDs and parent rating keys in one paginated operation. Build both
+    # lookup shapes once so a large Simkl import does not execute
+    # section/show/allLeaves requests for every episode individually.
     episode_guid_lookup: Dict[str, object] = {}
-    episode_position_lookup: Dict[Tuple[str, int, int], object] = {}
+    episode_show_position_lookup: Dict[Tuple[str, int, int], object] = {}
     if episodes:
         for section in plex.library.sections():
             if section.type != "show":
@@ -1026,18 +1032,37 @@ def update_plex(
                     ),
                     getattr(episode, "index", getattr(episode, "episodeNumber", None)),
                 )
-                if position_key:
-                    episode_position_lookup[position_key] = episode
+                parent_rating_key = getattr(episode, "grandparentRatingKey", None)
+                if position_key and parent_rating_key is not None:
+                    episode_show_position_lookup[
+                        (str(parent_rating_key), position_key[1], position_key[2])
+                    ] = episode
 
         logger.info(
-            "Built Plex episode lookup with %d GUID entries and %d episode positions",
+            "Built Plex episode lookup with %d GUID entries and %d exact show positions",
             len(episode_guid_lookup),
-            len(episode_position_lookup),
+            len(episode_show_position_lookup),
         )
 
-    # Only used if the bulk episode query was unavailable or an item lacked
-    # usable metadata.  Cache all leaves per show so even the compatibility
-    # fallback performs at most one remote lookup per show.
+    # Resolve each incoming show GUID at most once. The existing GUID index
+    # scans Plex shows once and then performs O(1) exact lookups.
+    resolved_show_lookup: Dict[str, Optional[object]] = {}
+
+    def resolve_show(show_guid: str) -> Optional[object]:
+        if show_guid not in resolved_show_lookup:
+            try:
+                show_obj = find_item_by_guid(plex, show_guid)
+                if show_obj and getattr(show_obj, "type", "show") != "show":
+                    show_obj = None
+            except Exception as exc:
+                logger.debug("Show GUID search failed for %s: %s", show_guid, exc)
+                show_obj = None
+            resolved_show_lookup[show_guid] = show_obj
+        return resolved_show_lookup[show_guid]
+
+    # Only used if the bulk episode query was unavailable or its episode rows
+    # lacked parent rating keys. Cache all leaves per exact show GUID so the
+    # compatibility path still performs at most one remote lookup per show.
     fallback_episode_lookup: Dict[str, Dict[Tuple[int, int], object]] = {}
 
     def log_progress(processed: int) -> None:
@@ -1056,47 +1081,39 @@ def update_plex(
         if guid and valid_guid(guid):
             try:
                 item = find_item_by_guid(plex, guid)
-                if item and _is_watched(item):
-                    continue
-                if item:
+                if item and getattr(item, "type", "movie") == "movie":
+                    if _is_watched(item):
+                        continue
                     item.markWatched()
                     movie_count += 1
                     continue
             except Exception as exc:
                 logger.debug("GUID search failed for %s: %s", guid, exc)
 
-        found = None
-        for section in plex.library.sections():
-            if section.type != "movie":
-                continue
-            try:
-                results = section.search(title=title)
-                for candidate in results:
-                    if year is None or normalize_year(getattr(candidate, "year", None)) == normalize_year(year):
-                        found = candidate
-                        break
-                if found:
-                    break
-            except Exception as exc:
-                logger.debug("Search failed in section %s: %s", section.title, exc)
-
-        if not found:
-            logger.debug("Movie not found in Plex library: %s (%s)", title, year)
-            continue
-
-        try:
-            if _is_watched(found):
-                continue
-            found.markWatched()
-            movie_count += 1
-        except Exception as exc:
-            logger.debug("Failed to mark movie '%s' as watched: %s", found.title, exc)
+        if guid:
+            logger.warning(
+                "Skipping unmatched Simkl movie '%s' (%s): "
+                "no Plex movie with GUID %s",
+                title,
+                year,
+                guid,
+            )
+        else:
+            logger.warning(
+                "Skipping unmatched Simkl movie '%s' (%s): "
+                "no external GUID available",
+                title,
+                year,
+            )
 
     for episode_index, (show_title, code, key) in enumerate(episodes, start=1):
         log_progress(len(movies) + episode_index - 1)
-        guid: Optional[str] = None
-        if isinstance(key, str):
-            guid = key if valid_guid(key) else None
+        episode_guid: Optional[str] = None
+        show_guid: Optional[str] = None
+        if isinstance(key, str) and valid_guid(key):
+            episode_guid = key
+        elif isinstance(key, tuple) and key and valid_guid(key[0]):
+            show_guid = key[0]
 
         try:
             season_num, episode_num = map(int, code.upper().lstrip("S").split("E"))
@@ -1104,11 +1121,14 @@ def update_plex(
             logger.debug("Invalid episode code format: %s", code)
             continue
 
-        item = episode_guid_lookup.get(guid) if guid else None
-        if item is None:
-            position_key = _episode_position_key(show_title, season_num, episode_num)
-            if position_key:
-                item = episode_position_lookup.get(position_key)
+        item = episode_guid_lookup.get(episode_guid) if episode_guid else None
+        show_obj = resolve_show(show_guid) if show_guid else None
+        if item is None and show_obj is not None:
+            show_rating_key = getattr(show_obj, "ratingKey", None)
+            if show_rating_key is not None:
+                item = episode_show_position_lookup.get(
+                    (str(show_rating_key), season_num, episode_num)
+                )
 
         if item is not None:
             try:
@@ -1121,40 +1141,62 @@ def update_plex(
                 logger.debug("Failed marking episode %s - %s as watched: %s", show_title, code, exc)
                 continue
 
-        normalized_show_title = " ".join((show_title or "").casefold().split())
-        if not normalized_show_title:
-            logger.debug("Episode has no show title and cannot be matched: %s", code)
-            continue
-        if normalized_show_title not in fallback_episode_lookup:
+        if show_guid and show_obj is not None and show_guid not in fallback_episode_lookup:
             show_episodes: Dict[Tuple[int, int], object] = {}
-            show_obj = get_show_from_library(plex, show_title)
-            if show_obj:
-                try:
-                    for show_episode in show_obj.episodes():
-                        show_episode_key = _episode_position_key(
-                            show_title,
-                            getattr(
-                                show_episode,
-                                "parentIndex",
-                                getattr(show_episode, "seasonNumber", None),
-                            ),
-                            getattr(
-                                show_episode,
-                                "index",
-                                getattr(show_episode, "episodeNumber", None),
-                            ),
-                        )
-                        if show_episode_key:
-                            show_episodes[(show_episode_key[1], show_episode_key[2])] = show_episode
-                except Exception as exc:
-                    logger.debug("Failed loading episodes for show %s: %s", show_title, exc)
-            fallback_episode_lookup[normalized_show_title] = show_episodes
+            try:
+                for show_episode in show_obj.episodes():
+                    show_episode_key = _episode_position_key(
+                        show_title,
+                        getattr(
+                            show_episode,
+                            "parentIndex",
+                            getattr(show_episode, "seasonNumber", None),
+                        ),
+                        getattr(
+                            show_episode,
+                            "index",
+                            getattr(show_episode, "episodeNumber", None),
+                        ),
+                    )
+                    if show_episode_key:
+                        show_episodes[(show_episode_key[1], show_episode_key[2])] = show_episode
+            except Exception as exc:
+                logger.debug(
+                    "Failed loading episodes for show GUID %s: %s",
+                    show_guid,
+                    exc,
+                )
+            fallback_episode_lookup[show_guid] = show_episodes
 
-        ep_obj = fallback_episode_lookup[normalized_show_title].get(
-            (season_num, episode_num)
+        ep_obj = (
+            fallback_episode_lookup.get(show_guid, {}).get((season_num, episode_num))
+            if show_guid
+            else None
         )
         if ep_obj is None:
-            logger.debug("Episode not found in Plex library: %s - %s", show_title, code)
+            if episode_guid:
+                logger.warning(
+                    "Skipping unmatched Simkl episode '%s' %s: "
+                    "no Plex episode with GUID %s",
+                    show_title,
+                    code,
+                    episode_guid,
+                )
+            elif show_guid:
+                logger.warning(
+                    "Skipping unmatched Simkl episode '%s' %s: "
+                    "no Plex episode under show GUID %s",
+                    show_title,
+                    code,
+                    show_guid,
+                )
+            else:
+                logger.warning(
+                    "Skipping unmatched Simkl episode '%s' %s: "
+                    "no usable external GUID available",
+                    show_title,
+                    code,
+                )
             continue
         try:
             if _is_watched(ep_obj):

--- a/simkl_utils.py
+++ b/simkl_utils.py
@@ -24,7 +24,7 @@ from utils import (
 logger = logging.getLogger(__name__)
 
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.5.6"
+APP_VERSION = "v0.5.7"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 CONFIG_DIR = os.environ.get("PLEXYTRACK_CONFIG_DIR", "/config")
 STATE_DIR = os.environ.get("PLEXYTRACK_STATE_DIR", "/state")

--- a/tests/test_simkl_strict_matching.py
+++ b/tests/test_simkl_strict_matching.py
@@ -1,0 +1,100 @@
+"""Regression coverage for strict Simkl-to-Plex watched matching."""
+
+from types import SimpleNamespace
+
+import plex_utils
+
+
+class DummyEpisode:
+    type = "episode"
+    isWatched = False
+    viewCount = 0
+
+    def __init__(self, title, parent_rating_key):
+        self.title = title
+        self.guid = f"plex://episode/{parent_rating_key}"
+        self.guids = []
+        self.grandparentTitle = "One Piece"
+        self.grandparentRatingKey = parent_rating_key
+        self.parentIndex = 1
+        self.index = 1
+        self.marked = False
+
+    def markWatched(self):
+        self.marked = True
+
+
+class DummyShowSection:
+    type = "show"
+    title = "TV Shows"
+
+    def __init__(self, episodes):
+        self._episodes = episodes
+
+    def all(self, libtype=None):
+        assert libtype == "episode"
+        return self._episodes
+
+
+def test_duplicate_show_title_uses_simkl_show_guid(monkeypatch):
+    anime_episode = DummyEpisode("Anime episode", "anime")
+    live_action_episode = DummyEpisode("Romance Dawn", "live-action")
+    plex = SimpleNamespace(
+        library=SimpleNamespace(
+            sections=lambda: [DummyShowSection([anime_episode, live_action_episode])]
+        )
+    )
+    live_action_show = SimpleNamespace(type="show", ratingKey="live-action")
+    monkeypatch.setattr(
+        plex_utils,
+        "find_item_by_guid",
+        lambda _plex, guid: (
+            live_action_show if guid == "imdb://tt11737520" else None
+        ),
+    )
+
+    plex_utils.update_plex(
+        plex,
+        set(),
+        {("One Piece", "S01E01", ("imdb://tt11737520", "S01E01"))},
+    )
+
+    assert live_action_episode.marked is True
+    assert anime_episode.marked is False
+
+
+def test_unknown_show_guid_never_falls_back_to_duplicate_title(monkeypatch):
+    anime_episode = DummyEpisode("Anime episode", "anime")
+    plex = SimpleNamespace(
+        library=SimpleNamespace(
+            sections=lambda: [DummyShowSection([anime_episode])]
+        )
+    )
+    monkeypatch.setattr(plex_utils, "find_item_by_guid", lambda *_args: None)
+
+    plex_utils.update_plex(
+        plex,
+        set(),
+        {("One Piece", "S01E01", ("imdb://tt11737520", "S01E01"))},
+    )
+
+    assert anime_episode.marked is False
+
+
+def test_unknown_movie_guid_never_falls_back_to_title(monkeypatch):
+    class MovieSection:
+        type = "movie"
+
+        def search(self, **_kwargs):
+            raise AssertionError("strict matching must not search by title")
+
+    plex = SimpleNamespace(
+        library=SimpleNamespace(sections=lambda: [MovieSection()])
+    )
+    monkeypatch.setattr(plex_utils, "find_item_by_guid", lambda *_args: None)
+
+    plex_utils.update_plex(
+        plex,
+        {("Dune", 2021, "imdb://tt1160419")},
+        set(),
+    )

--- a/tests/test_update_plex_performance.py
+++ b/tests/test_update_plex_performance.py
@@ -11,6 +11,7 @@ class DummyEpisode:
         self.guid = f"plex://episode/{number}"
         self.guids = [SimpleNamespace(id=f"tvdb://{1000 + number}")]
         self.grandparentTitle = "Example Show"
+        self.grandparentRatingKey = "show-1"
         self.parentIndex = 1
         self.index = number
         self.isWatched = False
@@ -49,7 +50,7 @@ class DummyLibrary:
         return [self._section]
 
 
-def test_update_plex_bulk_indexes_episodes_once():
+def test_update_plex_bulk_indexes_episodes_once(monkeypatch):
     counters = {
         "section_queries": 0,
         "bulk_episode_queries": 0,
@@ -59,6 +60,12 @@ def test_update_plex_bulk_indexes_episodes_once():
     library_episodes = [DummyEpisode(number, counters) for number in range(1, 101)]
     section = DummyShowSection(library_episodes, counters)
     plex = SimpleNamespace(library=DummyLibrary(section, counters))
+    exact_show = SimpleNamespace(type="show", ratingKey="show-1")
+    monkeypatch.setattr(
+        plex_utils,
+        "find_item_by_guid",
+        lambda _plex, guid: exact_show if guid == "tvdb://1" else None,
+    )
     service_episodes = {
         (
             "Example Show",
@@ -82,6 +89,8 @@ def test_update_plex_bulk_indexes_episodes_once():
 
 class DummyFallbackShow:
     title = "Example Show"
+    type = "show"
+    ratingKey = "show-1"
 
     def __init__(self, episodes, counters):
         self._episodes = episodes
@@ -106,7 +115,7 @@ class DummyFallbackSection(DummyShowSection):
         return self._show
 
 
-def test_update_plex_fallback_queries_each_show_once():
+def test_update_plex_fallback_queries_each_show_once(monkeypatch):
     counters = {
         "section_queries": 0,
         "bulk_episode_queries": 0,
@@ -117,6 +126,11 @@ def test_update_plex_fallback_queries_each_show_once():
     library_episodes = [DummyEpisode(number, counters) for number in range(1, 101)]
     section = DummyFallbackSection(library_episodes, counters)
     plex = SimpleNamespace(library=DummyLibrary(section, counters))
+    monkeypatch.setattr(
+        plex_utils,
+        "find_item_by_guid",
+        lambda _plex, guid: section._show if guid == "tvdb://1" else None,
+    )
     service_episodes = {
         ("Example Show", f"S01E{number:02d}", ("tvdb://1", f"S01E{number:02d}"))
         for number in range(1, 101)
@@ -125,9 +139,9 @@ def test_update_plex_fallback_queries_each_show_once():
     plex_utils.update_plex(plex, set(), service_episodes)
 
     assert counters == {
-        "section_queries": 2,
+        "section_queries": 1,
         "bulk_episode_queries": 1,
-        "show_queries": 1,
+        "show_queries": 0,
         "show_episode_queries": 1,
         "mark_watched": 100,
     }

--- a/trakt_utils.py
+++ b/trakt_utils.py
@@ -34,7 +34,7 @@ from utils import (
 logger = logging.getLogger(__name__)
 
 APP_NAME = "PlexyTrack"
-APP_VERSION = "v0.5.6"
+APP_VERSION = "v0.5.7"
 USER_AGENT = f"{APP_NAME} / {APP_VERSION}"
 CONFIG_DIR = os.environ.get("PLEXYTRACK_CONFIG_DIR", "/config")
 STATE_DIR = os.environ.get("PLEXYTRACK_STATE_DIR", "/state")


### PR DESCRIPTION
## Summary

- match Simkl movies and episodes to Plex strictly by external IDs
- resolve tuple-based episode keys through the exact Plex show GUID before applying season/episode coordinates
- skip and log unmatched items instead of falling back to ambiguous titles
- preserve the v0.5.6 bulk episode index by keying positions with the Plex parent rating key
- bump the application version and changelog to v0.5.7

## Verification

- confirmed v0.5.5 and v0.5.6 are ancestors of this branch
- confirmed no files from v0.5.6 are deleted
- `10 passed` across the v0.5.5 Simkl collection, v0.5.6 performance, and v0.5.7 strict-matching regression suites
- `223 passed` across the runnable repository suite
- local Docker Buildx preflight completed for `linux/amd64,linux/arm64`

## Documentation checked

- Simkl standard media objects: IDs are the canonical matching mechanism; title fallback can silently mismatch
- Python-PlexAPI library docs: exact lookup supports IMDb, TMDB, and TVDB GUIDs

Fixes #255